### PR TITLE
add methods to join multiple clump instances

### DIFF
--- a/src/main/scala/clump/Clump.scala
+++ b/src/main/scala/clump/Clump.scala
@@ -64,6 +64,49 @@ object Clump {
 
   def collect[T](clumps: List[Clump[T]]): Clump[List[T]] = new ClumpCollect(clumps)
 
+  def join[A, B](a: Clump[A], b: Clump[B]): Clump[(A, B)] =
+    a.join(b)
+
+  def join[A, B, C](a: Clump[A], b: Clump[B], c: Clump[C]): Clump[(A, B, C)] =
+    (join(a, b).join(c)).map {
+      case ((a, b), c) => (a, b, c)
+    }
+
+  def join[A, B, C, D](a: Clump[A], b: Clump[B], c: Clump[C], d: Clump[D]): Clump[(A, B, C, D)] =
+    (join(a, b, c).join(d)).map {
+      case ((a, b, c), d) => (a, b, c, d)
+    }
+
+  def join[A, B, C, D, E](a: Clump[A], b: Clump[B], c: Clump[C], d: Clump[D], e: Clump[E]): Clump[(A, B, C, D, E)] =
+    (join(a, b, c, d).join(e)).map {
+      case ((a, b, c, d), e) => (a, b, c, d, e)
+    }
+
+  def join[A, B, C, D, E, F](a: Clump[A], b: Clump[B], c: Clump[C], d: Clump[D], e: Clump[E], f: Clump[F]): Clump[(A, B, C, D, E, F)] =
+    (join(a, b, c, d, e).join(f)).map {
+      case ((a, b, c, d, e), f) => (a, b, c, d, e, f)
+    }
+  
+  def join[A, B, C, D, E, F, G](a: Clump[A], b: Clump[B], c: Clump[C], d: Clump[D], e: Clump[E], f: Clump[F], g: Clump[G]): Clump[(A, B, C, D, E, F, G)] =
+    (join(a, b, c, d, e, f).join(g)).map {
+      case ((a, b, c, d, e, f), g) => (a, b, c, d, e, f, g)
+    }
+  
+  def join[A, B, C, D, E, F, G, H](a: Clump[A], b: Clump[B], c: Clump[C], d: Clump[D], e: Clump[E], f: Clump[F], g: Clump[G], h: Clump[H]): Clump[(A, B, C, D, E, F, G, H)] =
+    (join(a, b, c, d, e, f, g).join(h)).map {
+      case ((a, b, c, d, e, f, g), h) => (a, b, c, d, e, f, g, h)
+    }
+  
+  def join[A, B, C, D, E, F, G, H, I](a: Clump[A], b: Clump[B], c: Clump[C], d: Clump[D], e: Clump[E], f: Clump[F], g: Clump[G], h: Clump[H], i: Clump[I]): Clump[(A, B, C, D, E, F, G, H, I)] =
+    (join(a, b, c, d, e, f, g, h).join(i)).map {
+      case ((a, b, c, d, e, f, g, h), i) => (a, b, c, d, e, f, g, h, i)
+    }
+  
+  def join[A, B, C, D, E, F, G, H, I, J](a: Clump[A], b: Clump[B], c: Clump[C], d: Clump[D], e: Clump[E], f: Clump[F], g: Clump[G], h: Clump[H], i: Clump[I], j: Clump[J]): Clump[(A, B, C, D, E, F, G, H, I, J)] =
+    (join(a, b, c, d, e, f, g, h, i).join(j)).map {
+      case ((a, b, c, d, e, f, g, h, i), j) => (a, b, c, d, e, f, g, h, i, j)
+    }
+
   def source[C] = new {
     def apply[T, U](fetch: C => Future[Iterable[U]])(keyExtractor: U => T)(implicit cbf: CanBuildFrom[Nothing, T, C]): ClumpSource[T, U] =
       ClumpSource(fetch)(keyExtractor)

--- a/src/test/scala/clump/ClumpApiSpec.scala
+++ b/src/test/scala/clump/ClumpApiSpec.scala
@@ -57,6 +57,48 @@ class ClumpApiSpec extends Spec {
     "allows to create an empty Clump (Clump.empty)" in {
       clumpResult(Clump.empty) ==== None
     }
+
+    "allows to join clumps" >> {
+      
+      def c(int: Int) = Clump.value(int)
+      
+      "2 instances" in {
+        val clump = Clump.join(c(1), c(2))
+        clumpResult(clump) mustEqual Some(1, 2)
+      }
+      "3 instances" in {
+        val clump = Clump.join(c(1), c(2), c(3))
+        clumpResult(clump) mustEqual Some(1, 2, 3)
+      }
+      "4 instances" in {
+        val clump = Clump.join(c(1), c(2), c(3), c(4))
+        clumpResult(clump) mustEqual Some(1, 2, 3, 4)
+      }
+      "5 instances" in {
+        val clump = Clump.join(c(1), c(2), c(3), c(4), c(5))
+        clumpResult(clump) mustEqual Some(1, 2, 3, 4, 5)
+      }
+      "6 instances" in {
+        val clump = Clump.join(c(1), c(2), c(3), c(4), c(5), c(6))
+        clumpResult(clump) mustEqual Some(1, 2, 3, 4, 5, 6)
+      }
+      "7 instances" in {
+        val clump = Clump.join(c(1), c(2), c(3), c(4), c(5), c(6), c(7))
+        clumpResult(clump) mustEqual Some(1, 2, 3, 4, 5, 6, 7)
+      }
+      "8 instances" in {
+        val clump = Clump.join(c(1), c(2), c(3), c(4), c(5), c(6), c(7), c(8))
+        clumpResult(clump) mustEqual Some(1, 2, 3, 4, 5, 6, 7, 8)
+      }
+      "9 instances" in {
+        val clump = Clump.join(c(1), c(2), c(3), c(4), c(5), c(6), c(7), c(8), c(9))
+        clumpResult(clump) mustEqual Some(1, 2, 3, 4, 5, 6, 7, 8, 9)
+      }
+      "10 instances" in {
+        val clump = Clump.join(c(1), c(2), c(3), c(4), c(5), c(6), c(7), c(8), c(9), c(10))
+        clumpResult(clump) mustEqual Some(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+      }
+    }
   }
 
   "a Clump instance" >> {


### PR DESCRIPTION
@williamboxhall I know that it is ugly, but scala doesn't support "tuple flattening". The Twitter Future also has these methods:

https://github.com/twitter/util/blob/master/util-core/src/main/scala/com/twitter/util/Future.scala#L198