### PR TITLE
support iterable outputs (Clump.sourceFrom)

### DIFF
--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -115,7 +115,7 @@ object Clump {
   }
 
   def sourceFrom[C] = new {
-    def apply[T, U](fetch: C => Future[Map[T, U]])(implicit cbf: CanBuildFrom[Nothing, T, C]): ClumpSource[T, U] =
+    def apply[T, U](fetch: C => Future[Iterable[(T, U)]])(implicit cbf: CanBuildFrom[Nothing, T, C]): ClumpSource[T, U] =
       ClumpSource.from(fetch)
   }
 

--- a/src/main/scala/io/getclump/ClumpSource.scala
+++ b/src/main/scala/io/getclump/ClumpSource.scala
@@ -29,8 +29,8 @@ private[getclump] object ClumpSource {
   def apply[T, U, C](fetch: C => Future[Iterable[U]])(keyExtractor: U => T)(implicit cbf: CanBuildFrom[Nothing, T, C]): ClumpSource[T, U] =
     new ClumpSource(FunctionIdentity(fetch), extractKeys(adaptInput(fetch), keyExtractor))
 
-  def from[T, U, C](fetch: C => Future[Map[T, U]])(implicit cbf: CanBuildFrom[Nothing, T, C]): ClumpSource[T, U] =
-    new ClumpSource(FunctionIdentity(fetch), adaptInput(fetch))
+  def from[T, U, C](fetch: C => Future[Iterable[(T, U)]])(implicit cbf: CanBuildFrom[Nothing, T, C]): ClumpSource[T, U] = 
+    new ClumpSource(FunctionIdentity(fetch), adaptOutput(adaptInput(fetch)))
 
   def zip[T, U](fetch: List[T] => Future[List[U]]): ClumpSource[T, U] = {
     new ClumpSource(FunctionIdentity(fetch), zipped(fetch))
@@ -52,4 +52,7 @@ private[getclump] object ClumpSource {
 
   private[this] def adaptInput[T, C, R](fetch: C => Future[R])(implicit cbf: CanBuildFrom[Nothing, T, C]) =
     (c: Set[T]) => fetch(cbf.apply().++=(c).result())
+    
+  private[this] def adaptOutput[T, U, C](fetch: C => Future[Iterable[(T, U)]]) =
+    fetch.andThen(_.map(_.toMap))
 }

--- a/src/test/scala/io/getclump/ClumpSourceSpec.scala
+++ b/src/test/scala/io/getclump/ClumpSourceSpec.scala
@@ -32,6 +32,11 @@ class ClumpSourceSpec extends Spec {
       val source = Clump.sourceFrom(fetch)
       clumpResult(source.get(1)) mustEqual Some("1")
     }
+    "iterable output" in {
+      def fetch(inputs: Set[Int]) = Future.value(inputs.map(i => i -> i.toString))
+      val source = Clump.sourceFrom(fetch)
+      clumpResult(source.get(1)) mustEqual Some("1")
+    }
     "expanded function" in {
       def fetch(int: Int, inputs: List[Int]) = Future.value(inputs.map(i => i -> i.toString).toMap)
       val source = Clump.sourceFrom[List[Int]](fetch(1, _))


### PR DESCRIPTION
@williamboxhall @grandbora Scrooge generates classes for the thrift IDLs that use `scala.collection.Map` instead of `scala.collection.immutable.Map`, so it isn't possible to use them directly. This PR changes the `Clump.sourceFrom` to accept `Iterable[(Key,Value)]`, that includes both.