### PR TITLE
overload `Clump.future` to accept both `Future[T]` and `Future[Option[T]]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ From a future:
 val clump: Clump[Int] = Clump.future(counterService.currentValueFor(111))
 ```
 
+The `future` method is overloaded to be able to receive both `Future[T]` and `Future[Option[T]]`.
+
 It is possible to create a failed Clump instance:
 
 ```scala

--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -5,6 +5,7 @@ import scala.collection.generic.CanBuildFrom
 import com.twitter.util.Future
 import com.twitter.util.Return
 import com.twitter.util.Throw
+import scala.reflect.ClassTag
 
 sealed trait Clump[+T] {
 
@@ -56,6 +57,8 @@ object Clump {
   def value[T](value: Option[T]): Clump[T] = future(Future.value(value))
 
   def exception[T](exception: Throwable): Clump[T] = future(Future.exception(exception))
+
+  def future[T: ClassTag](future: Future[T]): Clump[T] = new ClumpFuture(future.map(Option(_)))
 
   def future[T](future: Future[Option[T]]): Clump[T] = new ClumpFuture(future)
 

--- a/src/test/scala/io/getclump/ClumpApiSpec.scala
+++ b/src/test/scala/io/getclump/ClumpApiSpec.scala
@@ -14,8 +14,18 @@ class ClumpApiSpec extends Spec {
 
       "from a future (Clump.future)" >> {
 
-        "success" in {
-          clumpResult(Clump.future(Future.value(Some(1)))) mustEqual Some(1)
+        "success" >> {
+          "optional" >> {
+            "defined" in {
+              clumpResult(Clump.future(Future.value(Some(1)))) mustEqual Some(1)
+            }
+            "undefined" in {
+              clumpResult(Clump.future(Future.value(None))) mustEqual None
+            }
+          }
+          "non-optional" in {
+            clumpResult(Clump.future(Future.value(1))) mustEqual Some(1)
+          }
         }
 
         "failure" in {


### PR DESCRIPTION
@philwills @williamboxhall It is possible to overload because the `ClassTag` generates an implicit parameter that is provided automatically by the compiler, so the signature isn't the same and we can workaround the type erasure.