### PR TITLE
Get parameterization working elegantly

### DIFF
--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -120,6 +120,11 @@ object Clump {
       ClumpSource(fetch)(keyExtractor)
   }
 
+  def sourceWithParam[C] = new {
+    def apply[T, U, I](fetch: I => Future[Iterable[U]])(keyExtractor: U => T)(implicit cbf: CanBuildFrom[Nothing, T, C]): ClumpSourceWithParam[T, U, C, I] =
+      new ClumpSourceWithParam[T, U, C, I](fetch)(keyExtractor)
+  }
+
   def sourceFrom[C] = new {
     def apply[T, U](fetch: C => Future[Iterable[(T, U)]])(implicit cbf: CanBuildFrom[Nothing, T, C]): ClumpSource[T, U] =
       ClumpSource.from(fetch)

--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -120,9 +120,9 @@ object Clump {
       ClumpSource(fetch)(keyExtractor)
   }
 
-  def sourceWithParam[C] = new {
-    def apply[T, U, I](fetch: I => Future[Iterable[U]])(keyExtractor: U => T)(implicit cbf: CanBuildFrom[Nothing, T, C]): ClumpSourceWithParam[T, U, C, I] =
-      new ClumpSourceWithParam[T, U, C, I](fetch)(keyExtractor)
+  def sourceWithParam[P, C] = new {
+    def apply[T, U](fetch: (P, C) => Future[Iterable[U]])(keyExtractor: U => T)(implicit cbf: CanBuildFrom[Nothing, T, C]): ClumpSourceWithParam[T, U, P] =
+      ClumpSourceWithParam.apply(fetch)(keyExtractor)
   }
 
   def sourceFrom[C] = new {

--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -120,11 +120,6 @@ object Clump {
       ClumpSource(fetch)(keyExtractor)
   }
 
-  def sourceWithParam[P, C] = new {
-    def apply[T, U](fetch: (P, C) => Future[Iterable[U]])(keyExtractor: U => T)(implicit cbf: CanBuildFrom[Nothing, T, C]): ClumpSourceWithParam[T, U, P] =
-      ClumpSourceWithParam.apply(fetch)(keyExtractor)
-  }
-
   def sourceFrom[C] = new {
     def apply[T, U](fetch: C => Future[Iterable[(T, U)]])(implicit cbf: CanBuildFrom[Nothing, T, C]): ClumpSource[T, U] =
       ClumpSource.from(fetch)
@@ -132,6 +127,19 @@ object Clump {
 
   def sourceZip[T, U](fetch: List[T] => Future[List[U]]): ClumpSource[T, U] =
     ClumpSource.zip(fetch)
+
+  def sourceWithParam[P, C] = new {
+    def apply[T, U](fetch: (P, C) => Future[Iterable[U]])(keyExtractor: U => T)(implicit cbf: CanBuildFrom[Nothing, T, C]): ClumpSourceWithParam[T, U, P] =
+      ClumpSourceWithParam.apply(fetch)(keyExtractor)
+  }
+
+  def sourceWithParamFrom[P, C] = new {
+    def apply[T, U](fetch: (P, C) => Future[Iterable[(T, U)]])(implicit cbf: CanBuildFrom[Nothing, T, C]): ClumpSourceWithParam[T, U, P] =
+      ClumpSourceWithParam.from(fetch)
+  }
+
+  def sourceWithParamZip[T, U, P](fetch: (P, List[T]) => Future[List[U]]): ClumpSourceWithParam[T, U, P] =
+    ClumpSourceWithParam.zip(fetch)
 }
 
 private[getclump] class ClumpFuture[T](val result: Future[Option[T]]) extends Clump[T] {

--- a/src/main/scala/io/getclump/ClumpSource.scala
+++ b/src/main/scala/io/getclump/ClumpSource.scala
@@ -3,6 +3,12 @@ package io.getclump
 import com.twitter.util.Future
 import scala.collection.generic.CanBuildFrom
 
+class ClumpSourceWithParam[T, U, C, I](fetch: I => Future[Iterable[U]])(keyExtractor: U => T)(implicit cbf: CanBuildFrom[Nothing, T, C]) {
+  def apply(parameterize : (C) => I): ClumpSource[T, U] = {
+    ClumpSource(parameterize andThen fetch)(keyExtractor)(cbf)
+  }
+}
+
 class ClumpSource[T, U] private[ClumpSource] (val functionIdentity: FunctionIdentity,
                                               val fetch: Set[T] => Future[Map[T, U]],
                                               val maxBatchSize: Int = Int.MaxValue,

--- a/src/main/scala/io/getclump/ClumpSource.scala
+++ b/src/main/scala/io/getclump/ClumpSource.scala
@@ -3,16 +3,69 @@ package io.getclump
 import com.twitter.util.Future
 import scala.collection.generic.CanBuildFrom
 
-class ClumpSourceWithParam[T, U, C, I](fetch: I => Future[Iterable[U]])(keyExtractor: U => T)(implicit cbf: CanBuildFrom[Nothing, T, C]) {
-  def apply(parameterize : (C) => I): ClumpSource[T, U] = {
-    ClumpSource(parameterize andThen fetch)(keyExtractor)(cbf)
+class ClumpSourceWithParam[T, U, P](val functionIdentity: FunctionIdentity,
+                                    val fetch: ((P, Set[T])) => Future[Map[T, U]],
+                                    val maxBatchSize: Int = Int.MaxValue,
+                                    val _maxRetries: PartialFunction[Throwable, Int] = PartialFunction.empty) {
+
+  def get(param: P, inputs: T*): Clump[List[U]] =
+    get(param, inputs.toList)
+
+  def get(param: P, inputs: List[T]): Clump[List[U]] =
+    Clump.collect(inputs.map(get(param, _)))
+
+  def get(param: P, input: T): Clump[U] = {
+    val parameterized: Set[T] => Future[Map[T, U]] = fetch(param, _)
+    val clumpSource: ClumpSource[T, U] = new ClumpSource[T, U](functionIdentity, parameterized, maxBatchSize, _maxRetries)
+    new ClumpFetch(input, ClumpContext().fetcherFor(clumpSource))
   }
+
+  def maxBatchSize(size: Int): ClumpSourceWithParam[T, U, P] =
+    new ClumpSourceWithParam(functionIdentity, fetch, size, _maxRetries)
+
+  def maxRetries(retries: PartialFunction[Throwable, Int]): ClumpSourceWithParam[T, U, P] =
+    new ClumpSourceWithParam(functionIdentity, fetch, maxBatchSize, retries)
 }
 
-class ClumpSource[T, U] private[ClumpSource] (val functionIdentity: FunctionIdentity,
-                                              val fetch: Set[T] => Future[Map[T, U]],
-                                              val maxBatchSize: Int = Int.MaxValue,
-                                              val _maxRetries: PartialFunction[Throwable, Int] = PartialFunction.empty) {
+private[getclump] object ClumpSourceWithParam {
+
+  def apply[T, U, C, P](fetch: (P, C) => Future[Iterable[U]])(keyExtractor: U => T)(implicit cbf: CanBuildFrom[Nothing, T, C]): ClumpSourceWithParam[T, U, P] =
+    new ClumpSourceWithParam(FunctionIdentity(fetch), extractKeys(adaptInput(fetch), keyExtractor))
+
+  def from[T, U, C, P](fetch: (P, C) => Future[Iterable[(T, U)]])(implicit cbf: CanBuildFrom[Nothing, T, C]): ClumpSourceWithParam[T, U, P] =
+    new ClumpSourceWithParam(FunctionIdentity(fetch), adaptOutput(adaptInput(fetch)))
+
+  def zip[T, U, P](fetch: (P, List[T]) => Future[List[U]]): ClumpSourceWithParam[T, U, P] = {
+    new ClumpSourceWithParam(FunctionIdentity(fetch), zipped(fetch))
+  }
+
+  private[this] def zipped[T, U, P](fetch: (P, List[T]) => Future[List[U]]) = {
+    val zip: ((P, List[T])) => Future[Map[T, U]] = { case ((param, inputs)) =>
+      fetch(param, inputs).map(inputs.zip(_).toMap)
+    }
+    val setToList: (P, Set[T]) => (P, List[T]) = { (param, input) => (param, input.toList) }
+    setToList.tupled.andThen(zip)
+  }
+
+  private[this] def extractKeys[T, U, P](fetch: (P, Set[T]) => Future[Iterable[U]], keyExtractor: U => T) = {
+    val map: (Future[Iterable[U]]) => Future[Map[T, U]] = _.map(resultsToKeys(keyExtractor, _))
+    fetch.tupled.andThen(map)
+  }
+
+  private[this] def resultsToKeys[U, T](keyExtractor: (U) => T, results: Iterable[U]) =
+    results.map(v => (keyExtractor(v), v)).toMap
+
+  private[this] def adaptInput[T, C, R, P](fetch: (P, C) => Future[R])(implicit cbf: CanBuildFrom[Nothing, T, C]) =
+    (p: P, c: Set[T]) => fetch(p, cbf.apply().++=(c).result())
+
+  private[this] def adaptOutput[T, U, C, P](fetch: (P, C) => Future[Iterable[(T, U)]]) =
+    fetch.tupled.andThen(_.map(_.toMap))
+}
+
+class ClumpSource[T, U](val functionIdentity: FunctionIdentity,
+                        val fetch: Set[T] => Future[Map[T, U]],
+                        val maxBatchSize: Int = Int.MaxValue,
+                        val _maxRetries: PartialFunction[Throwable, Int] = PartialFunction.empty) {
 
   def get(inputs: T*): Clump[List[U]] =
     get(inputs.toList)

--- a/src/main/scala/io/getclump/ClumpSource.scala
+++ b/src/main/scala/io/getclump/ClumpSource.scala
@@ -3,7 +3,7 @@ package io.getclump
 import com.twitter.util.Future
 import scala.collection.generic.CanBuildFrom
 
-class ClumpSourceWithParam[T, U, P](val unparameterized: (P) => ClumpSource[T, U]) {
+class ClumpSourceWithParam[T, U, P] private[ClumpSourceWithParam] (val unparameterized: (P) => ClumpSource[T, U]) {
 
   def get(param: P, inputs: T*): Clump[List[U]] =
     unparameterized(param).get(inputs: _*)
@@ -36,10 +36,10 @@ private[getclump] object ClumpSourceWithParam {
   }
 }
 
-class ClumpSource[T, U](val functionIdentity: FunctionIdentity,
-                        val fetch: Set[T] => Future[Map[T, U]],
-                        val maxBatchSize: Int = Int.MaxValue,
-                        val _maxRetries: PartialFunction[Throwable, Int] = PartialFunction.empty) {
+class ClumpSource[T, U] private[ClumpSource] (val functionIdentity: FunctionIdentity,
+                                              val fetch: Set[T] => Future[Map[T, U]],
+                                              val maxBatchSize: Int = Int.MaxValue,
+                                              val _maxRetries: PartialFunction[Throwable, Int] = PartialFunction.empty) {
 
   def get(inputs: T*): Clump[List[U]] =
     get(inputs.toList)

--- a/src/test/scala/io/getclump/ClumpSourceSpec.scala
+++ b/src/test/scala/io/getclump/ClumpSourceSpec.scala
@@ -62,6 +62,12 @@ class ClumpSourceSpec extends Spec {
     }
   }
 
+  "allows to create a clump source with key function and parameter (ClumpSource.apply)" in {
+      def fetch(session: Long, inputs: Set[Int]) = Future.value(inputs.map(_.toString))
+      val source = Clump.sourceWithParam[Set[Int]].apply[Int, String, (Long, Set[Int])]({ case ((session, inputs)) => fetch(session, inputs)})(_.toInt)
+      clumpResult(source((2L, _)).get(1)) mustEqual Some("1")
+  }
+
   "allows to create a clump source with zip as the key function (ClumpSource.zip)" in {
     def fetch(inputs: List[Int]) = Future.value(inputs.map(_.toString))
     val source = Clump.sourceZip(fetch)

--- a/src/test/scala/io/getclump/ClumpSourceSpec.scala
+++ b/src/test/scala/io/getclump/ClumpSourceSpec.scala
@@ -62,10 +62,10 @@ class ClumpSourceSpec extends Spec {
     }
   }
 
-  "allows to create a clump source with key function and parameter (ClumpSource.apply)" in {
-      def fetch(session: Long, inputs: Set[Int]) = Future.value(inputs.map(_.toString))
-      val source = Clump.sourceWithParam[Set[Int]].apply[Int, String, (Long, Set[Int])]({ case ((session, inputs)) => fetch(session, inputs)})(_.toInt)
-      clumpResult(source((2L, _)).get(1)) mustEqual Some("1")
+  "allows to create a clump source with key function and parameter (ClumpSourceWithParameter.apply)" in {
+      def fetch(session: String, inputs: Set[Int]) = Future.value(inputs.map(_.toString))
+      val source = Clump.sourceWithParam(fetch)(_.toInt)
+      clumpResult(source.get("session", 1)) mustEqual Some("1")
   }
 
   "allows to create a clump source with zip as the key function (ClumpSource.zip)" in {

--- a/src/test/scala/io/getclump/ClumpSourceSpec.scala
+++ b/src/test/scala/io/getclump/ClumpSourceSpec.scala
@@ -62,12 +62,6 @@ class ClumpSourceSpec extends Spec {
     }
   }
 
-  "allows to create a clump source with key function and parameter (ClumpSourceWithParameter.apply)" in {
-      def fetch(session: String, inputs: Set[Int]) = Future.value(inputs.map(_.toString))
-      val source = Clump.sourceWithParam(fetch)(_.toInt)
-      clumpResult(source.get("session", 1)) mustEqual Some("1")
-  }
-
   "allows to create a clump source with zip as the key function (ClumpSource.zip)" in {
     def fetch(inputs: List[Int]) = Future.value(inputs.map(_.toString))
     val source = Clump.sourceZip(fetch)
@@ -113,6 +107,24 @@ class ClumpSourceSpec extends Spec {
     testSource(ClumpSource.from(setToMap))
     testSource(ClumpSource.from(listToMap))
     testSource(ClumpSource.from(iterableToMap))
+  }
+
+  "allows to create a clump source with a parameter (ClumpSourceWithParam.from)" in {
+    def fetch(session: String, inputs: Set[Int]) = Future.value(inputs.map(i => i -> i.toString).toMap)
+    val source = Clump.sourceWithParamFrom(fetch)
+    clumpResult(source.get("session", 1)) mustEqual Some("1")
+  }
+
+  "allows to create a clump source with key function and parameter (ClumpSourceWithParam.apply)" in {
+    def fetch(session: String, inputs: Set[Int]) = Future.value(inputs.map(_.toString))
+    val source = Clump.sourceWithParam(fetch)(_.toInt)
+    clumpResult(source.get("session", 1)) mustEqual Some("1")
+  }
+
+  "allows to create a clump source with a parameter with zip as the key function (ClumpSourceWithParam.zip)" in {
+    def fetch(session: String, inputs: List[Int]) = Future.value(inputs.map(_.toString))
+    val source = Clump.sourceWithParamZip(fetch)
+    clumpResult(source.get("session", 1)) mustEqual Some("1")
   }
 
   "fetches an individual clump" in new Context {


### PR DESCRIPTION
@fwbrasil I thought I found an elegant way to express when a `ClumpSource` requires additional parameters.

Unfortunately, to do this generically, the Type of the input function needs to be a tuple rather than a 2 args, which makes it kind of ugly if you ask me - see the spec for an example of what I mean 