### PR TITLE
Add scaladoc to all public methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ val clump: Clump[User] =
 Clump uses Twitter Futures by default, but it is possible to use Scala Futures by importing the ```FutureBridge```:
 
 ```scala
-import clump.FutureBridge._
+import io.getclump.FutureBridge._
 
 val userClump: Clump[User] = ...
 val future: scala.concurrent.Future[User] = userClump.get

--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -11,31 +11,72 @@ sealed trait Clump[+T] {
 
   private[this] val context = ClumpContext()
 
+  /**
+   * Create a new clump by applying a function to the result of this clump
+   */
   def map[U](f: T => U): Clump[U] = new ClumpMap(this, f)
 
+  /**
+   * Create a new clump by applying a function that returns a clump to the result of this clump
+   */
   def flatMap[U](f: T => Clump[U]): Clump[U] = new ClumpFlatMap(this, f)
 
+  /**
+   * Join this clump to another clump so that the result is a clump holding a pair of values
+   */
   def join[U](other: Clump[U]): Clump[(T, U)] = new ClumpJoin(this, other)
 
+  /**
+   * Define a fallback value to use in the case of specified exceptions
+   */
   def handle[B >: T](f: PartialFunction[Throwable, Option[B]]): Clump[B] = new ClumpHandle(this, f)
 
+  /**
+   * Define a fallback clump to use in the case of specified exceptions
+   */
   def rescue[B >: T](f: PartialFunction[Throwable, Clump[B]]): Clump[B] = new ClumpRescue(this, f)
 
+  /**
+   * Alias for [[filter]] used by for-comprehensions
+   */
   def withFilter[B >: T](f: B => Boolean): Clump[B] = filter(f)
 
+  /**
+   * Apply a filter to this clump so that the result will only be defined if the predicate function returns true
+   */
   def filter[B >: T](f: B => Boolean): Clump[B] = new ClumpFilter(this, f)
 
+  /**
+   * If this clump does not return a value then use the value from a default clump instead
+   */
   def orElse[B >: T](default: => Clump[B]): Clump[B] = new ClumpOrElse(this, default)
 
+  /**
+   * Mark a clump as optional so that its underlying value is an option to avoid lossy joins
+   */
   def optional: Clump[Option[T]] = new ClumpOptional(this)
 
+  /**
+   * A utility method for automatically unwrapping the underlying value
+   * @throws NoSuchElementException if the underlying value is not defined
+   */
   def apply(): Future[T] = get.map(_.get)
 
+  /**
+   * Get the result of the clump or provide a fallback value in the case where the result is not defined
+   */
   def getOrElse[B >: T](default: => B): Future[B] = get.map(_.getOrElse(default))
 
+  /**
+   * If the underlying value is a list, then this will return Nil instead of None when the result is not defined
+   */
   def list[B >: T](implicit cbf: CanBuildFrom[Nothing, Nothing, B]): Future[B] =
     get.map(_.getOrElse(cbf().result))
 
+  /**
+   * Trigger execution of a clump. The result will not be defined if any of the clump sources returned less elements
+   * than requested.
+   */
   def get: Future[Option[T]] =
     context
       .flush(List(this))
@@ -50,25 +91,65 @@ sealed trait Clump[+T] {
 
 object Clump extends Joins with Sources {
 
+  /**
+   * Create an empty clump
+   */
   def empty[T]: Clump[T] = value(scala.None)
 
+  /**
+   * The unit method: create a clump whose value has already been resolved to the input
+   */
   def value[T](value: T): Clump[T] = future(Future.value(Option(value)))
 
+  /**
+   * The unit method: create a clump whose value has already been resolved to the input if it is defined
+   */
   def value[T](value: Option[T]): Clump[T] = future(Future.value(value))
 
+  /**
+   * Create a failed clump with the given exception
+   */
   def exception[T](exception: Throwable): Clump[T] = future(Future.exception(exception))
 
+  /**
+   * Create a clump whose value will be the result of the inputted future
+   */
   def future[T: ClassTag](future: Future[T]): Clump[T] = new ClumpFuture(future.map(Option(_)))
 
+  /**
+   * Create a clump whose value will be the result of the inputted future if it is defined
+   */
   def future[T](future: Future[Option[T]]): Clump[T] = new ClumpFuture(future)
 
+  /**
+   * Transform a number of values into a single clump by first applying a function.
+   *
+   * Equivalent to:
+   * {{{
+   *   Clump.collect(clump1.map(f), clump2.map(f))
+   * }}}
+   */
   def traverse[T, U](inputs: T*)(f: T => Clump[U]): Clump[List[U]] = traverse(inputs.toList)(f)
 
+  /**
+   * Transform a number of clump instances into a single clump
+   */
   def collect[T](clumps: Clump[T]*): Clump[List[T]] = collect(clumps.toList)
 
+  /**
+   * Transform a collection of clump instances into a single clump by first applying a function.
+   *
+   * Equivalent to:
+   * {{{
+   *   Clump.collect(list.map(f))
+   * }}}
+   */
   def traverse[T, U, C[_] <: Iterable[_]](inputs: C[T])(f: T => Clump[U])(implicit cbf: CanBuildFrom[Nothing, U, C[U]]): Clump[C[U]] =
     collect(inputs.toList.asInstanceOf[List[T]].map(f)).map(cbf.apply().++=(_).result())
 
+  /**
+   * Transform a collection of clump instances into a single clump
+   */
   def collect[T, C[_] <: Iterable[_]](clumps: C[Clump[T]])(implicit cbf: CanBuildFrom[C[Clump[T]], T, C[T]]): Clump[C[T]] =
     new ClumpCollect(clumps)
 

--- a/src/main/scala/io/getclump/ClumpSource.scala
+++ b/src/main/scala/io/getclump/ClumpSource.scala
@@ -8,15 +8,28 @@ class ClumpSource[T, U] private[getclump] (val functionIdentity: FunctionIdentit
                                               val maxBatchSize: Int = Int.MaxValue,
                                               val _maxRetries: PartialFunction[Throwable, Int] = PartialFunction.empty) {
 
+  /**
+   * Get a list of values from a clump source
+   */
   def get(inputs: List[T]): Clump[List[U]] =
     Clump.collect(inputs.map(get))
 
+  /**
+   * Get a single value from a clump source
+   */
   def get(input: T): Clump[U] =
     new ClumpFetch(input, ClumpContext().fetcherFor(this))
 
+  /**
+   * Set the maximum batch size for fetching values from this clump source
+   */
   def maxBatchSize(size: Int): ClumpSource[T, U] =
     new ClumpSource(functionIdentity, fetch, size, _maxRetries)
 
+  /**
+   * Set the maximum number of retries for fetching values from this clump source in case of failure.
+   * Different number of retries can be set for different types of exceptions.
+   */
   def maxRetries(retries: PartialFunction[Throwable, Int]): ClumpSource[T, U] =
     new ClumpSource(functionIdentity, fetch, maxBatchSize, retries)
 }

--- a/src/main/scala/io/getclump/FutureBridge.scala
+++ b/src/main/scala/io/getclump/FutureBridge.scala
@@ -9,8 +9,19 @@ import scala.util.Success
 import com.twitter.util.{Future => TwitterFuture}
 import com.twitter.util.{Promise => TwitterPromise}
 
+/**
+ * Provides bidirectional implicit conversions between Twitter Futures and Scala Futures
+ *
+ * Usage:
+ * {{{
+ *   import io.getclump.FutureBridge._
+ * }}}
+ */
 object FutureBridge {
 
+  /**
+   * Convert a Twitter Future to a Scala Future
+   */
   implicit def twitterToScala[T](future: TwitterFuture[T]): ScalaFuture[T] = {
     val promise = ScalaPromise[T]()
     future.onSuccess(promise.success)
@@ -18,6 +29,9 @@ object FutureBridge {
     promise.future
   }
 
+  /**
+   * Convert a Scala Future to a Twitter Future given an execution context
+   */
   implicit def scalaToTwitter[T](future: ScalaFuture[T])(implicit ctx: ExecutionContext): TwitterFuture[T] = {
     val promise = TwitterPromise[T]()
     future.onComplete {

--- a/src/main/scala/io/getclump/Joins.scala
+++ b/src/main/scala/io/getclump/Joins.scala
@@ -1,44 +1,71 @@
 package io.getclump
 
 protected[getclump] trait Joins {
+  /**
+   * Join 2 clumps into a single clump containing a Tuple2
+   */
   def join[A, B](a: Clump[A], b: Clump[B]): Clump[(A, B)] =
     a.join(b)
 
+  /**
+   * Join 3 clumps into a single clump containing a Tuple3
+   */
   def join[A, B, C](a: Clump[A], b: Clump[B], c: Clump[C]): Clump[(A, B, C)] =
     (join(a, b).join(c)).map {
       case ((a, b), c) => (a, b, c)
     }
 
+  /**
+   * Join 4 clumps into a single clump containing a Tuple4
+   */
   def join[A, B, C, D](a: Clump[A], b: Clump[B], c: Clump[C], d: Clump[D]): Clump[(A, B, C, D)] =
     (join(a, b, c).join(d)).map {
       case ((a, b, c), d) => (a, b, c, d)
     }
 
+  /**
+   * Join 5 clumps into a single clump containing a Tuple5
+   */
   def join[A, B, C, D, E](a: Clump[A], b: Clump[B], c: Clump[C], d: Clump[D], e: Clump[E]): Clump[(A, B, C, D, E)] =
     (join(a, b, c, d).join(e)).map {
       case ((a, b, c, d), e) => (a, b, c, d, e)
     }
 
+  /**
+   * Join 6 clumps into a single clump containing a Tuple6
+   */
   def join[A, B, C, D, E, F](a: Clump[A], b: Clump[B], c: Clump[C], d: Clump[D], e: Clump[E], f: Clump[F]): Clump[(A, B, C, D, E, F)] =
     (join(a, b, c, d, e).join(f)).map {
       case ((a, b, c, d, e), f) => (a, b, c, d, e, f)
     }
 
+  /**
+   * Join 7 clumps into a single clump containing a Tuple7
+   */
   def join[A, B, C, D, E, F, G](a: Clump[A], b: Clump[B], c: Clump[C], d: Clump[D], e: Clump[E], f: Clump[F], g: Clump[G]): Clump[(A, B, C, D, E, F, G)] =
     (join(a, b, c, d, e, f).join(g)).map {
       case ((a, b, c, d, e, f), g) => (a, b, c, d, e, f, g)
     }
 
+  /**
+   * Join 8 clumps into a single clump containing a Tuple8
+   */
   def join[A, B, C, D, E, F, G, H](a: Clump[A], b: Clump[B], c: Clump[C], d: Clump[D], e: Clump[E], f: Clump[F], g: Clump[G], h: Clump[H]): Clump[(A, B, C, D, E, F, G, H)] =
     (join(a, b, c, d, e, f, g).join(h)).map {
       case ((a, b, c, d, e, f, g), h) => (a, b, c, d, e, f, g, h)
     }
 
+  /**
+   * Join 9 clumps into a single clump containing a Tuple9
+   */
   def join[A, B, C, D, E, F, G, H, I](a: Clump[A], b: Clump[B], c: Clump[C], d: Clump[D], e: Clump[E], f: Clump[F], g: Clump[G], h: Clump[H], i: Clump[I]): Clump[(A, B, C, D, E, F, G, H, I)] =
     (join(a, b, c, d, e, f, g, h).join(i)).map {
       case ((a, b, c, d, e, f, g, h), i) => (a, b, c, d, e, f, g, h, i)
     }
 
+  /**
+   * Join 10 clumps into a single clump containing a Tuple10
+   */
   def join[A, B, C, D, E, F, G, H, I, J](a: Clump[A], b: Clump[B], c: Clump[C], d: Clump[D], e: Clump[E], f: Clump[F], g: Clump[G], h: Clump[H], i: Clump[I], j: Clump[J]): Clump[(A, B, C, D, E, F, G, H, I, J)] =
     (join(a, b, c, d, e, f, g, h, i).join(j)).map {
       case ((a, b, c, d, e, f, g, h, i), j) => (a, b, c, d, e, f, g, h, i, j)

--- a/src/main/scala/io/getclump/Sources.scala
+++ b/src/main/scala/io/getclump/Sources.scala
@@ -6,58 +6,107 @@ import scala.collection.generic.CanBuildFrom
 
 protected[getclump] trait Sources extends Tuples {
 
+  /**
+   * Create a clump source from a function that accepts inputs and returns a future list of values.
+   * Since the order of the list of values is undefined, also must provide a function that takes the value and returns
+   * the key used to get that value.
+   */
   def source[KS, V, K](fetch: KS => Future[Iterable[V]])(keyExtractor: V => K)
                       (implicit cbf: CanBuildFrom[Nothing, K, KS]): ClumpSource[K, V] =
     new ClumpSource(FunctionIdentity(fetch), extractKeys(adaptInput(fetch), keyExtractor))
 
+  /**
+   * Similar to [[source]] but also accepts 1 extra params
+   */
   def source[A, KS, V, K](fetch: (A, KS) => Future[Iterable[V]])(keyExtractor: V => K)
                          (implicit cbf: CanBuildFrom[Nothing, K, KS]): ClumpSource[(A, K), V] =
     new ClumpSource(FunctionIdentity(fetch), parameterizeFetch(normalize1, denormalize1[A, K], fetch1(fetch), keyExtractor))
 
+  /**
+   * Similar to [[source]] but also accepts 2 extra params
+   */
   def source[A, B, KS, V, K](fetch: (A, B, KS) => Future[Iterable[V]])(keyExtractor: V => K)
                             (implicit cbf: CanBuildFrom[Nothing, K, KS]): ClumpSource[(A, B, K), V] =
     new ClumpSource(FunctionIdentity(fetch), parameterizeFetch(normalize2, denormalize2[A, B, K], fetch2(fetch), keyExtractor))
 
+  /**
+   * Similar to [[source]] but also accepts 3 extra params
+   */
   def source[A, B, C, KS, V, K](fetch: (A, B, C, KS) => Future[Iterable[V]])(keyExtractor: V => K)
                                (implicit cbf: CanBuildFrom[Nothing, K, KS]): ClumpSource[(A, B, C, K), V] =
     new ClumpSource(FunctionIdentity(fetch), parameterizeFetch(normalize3, denormalize3[A, B, C, K], fetch3(fetch), keyExtractor))
 
+  /**
+   * Similar to [[source]] but also accepts 4 extra params
+   */
   def source[A, B, C, D, KS, V, K](fetch: (A, B, C, D, KS) => Future[Iterable[V]])(keyExtractor: V => K)
                                   (implicit cbf: CanBuildFrom[Nothing, K, KS]): ClumpSource[(A, B, C, D, K), V] =
     new ClumpSource(FunctionIdentity(fetch), parameterizeFetch(normalize4, denormalize4[A, B, C, D, K], fetch4(fetch), keyExtractor))
 
+  /**
+   * Create a clump source from a function that accepts inputs and returns a future map from input to resulting value.
+   */
   def source[KS, K, V](fetch: KS => Future[Map[K, V]])
                       (implicit cbf: CanBuildFrom[Nothing, K, KS]): ClumpSource[K, V] =
     new ClumpSource(FunctionIdentity(fetch), adaptOutput(adaptInput(fetch)))
 
+  /**
+   * Similar to [[source]] but also accepts 1 extra params
+   */
   def source[A, KS, K, V](fetch: (A, KS) => Future[Map[K, V]])
                          (implicit cbf: CanBuildFrom[Nothing, K, KS]): ClumpSource[(A, K), V] =
     new ClumpSource(FunctionIdentity(fetch), parameterizeFetch(normalize1, denormalize1[A, K], fetch1(fetch)))
 
+  /**
+   * Similar to [[source]] but also accepts 2 extra params
+   */
   def source[A, B, KS, K, V](fetch: (A, B, KS) => Future[Map[K, V]])
                             (implicit cbf: CanBuildFrom[Nothing, K, KS]): ClumpSource[(A, B, K), V] =
     new ClumpSource(FunctionIdentity(fetch), parameterizeFetch(normalize2, denormalize2[A, B, K], fetch2(fetch)))
 
+  /**
+   * Similar to [[source]] but also accepts 3 extra params
+   */
   def source[A, B, C, KS, K, V](fetch: (A, B, C, KS) => Future[Map[K, V]])
                                (implicit cbf: CanBuildFrom[Nothing, K, KS]): ClumpSource[(A, B, C, K), V] =
     new ClumpSource(FunctionIdentity(fetch), parameterizeFetch(normalize3, denormalize3[A, B, C, K], fetch3(fetch)))
 
+  /**
+   * Similar to [[source]] but also accepts 4 extra params
+   */
   def source[A, B, C, D, KS, K, V](fetch: (A, B, C, D, KS) => Future[Map[K, V]])
                                   (implicit cbf: CanBuildFrom[Nothing, K, KS]): ClumpSource[(A, B, C, D, K), V] =
     new ClumpSource(FunctionIdentity(fetch), parameterizeFetch(normalize4, denormalize4[A, B, C, D, K], fetch4(fetch)))
 
+  /**
+   * Create a clump source from a function that accepts inputs and returns a future list of values.
+   * Unlike in [[source]], the order of the returned values must be the same as the list of keys that was passed in as
+   * the key and value lists will be zipped together to create a map from key to value.
+   */
   def sourceZip[K, V](fetch: List[K] => Future[List[V]]): ClumpSource[K, V] =
     new ClumpSource(FunctionIdentity(fetch), zipped(fetch))
 
+  /**
+   * Similar to [[sourceZip]] but also accepts 1 extra params
+   */
   def sourceZip[A, K, V](fetch: (A, List[K]) => Future[List[V]]): ClumpSource[(A, K), V] =
     new ClumpSource(FunctionIdentity(fetch), parameterizeFetchZip(normalize1, fetch1(fetch)))
 
+  /**
+   * Similar to [[sourceZip]] but also accepts 2 extra params
+   */
   def sourceZip[A, B, K, V](fetch: (A, B, List[K]) => Future[List[V]]): ClumpSource[(A, B, K), V] =
     new ClumpSource(FunctionIdentity(fetch), parameterizeFetchZip(normalize2, fetch2(fetch)))
 
+  /**
+   * Similar to [[sourceZip]] but also accepts 3 extra params
+   */
   def sourceZip[A, B, C, K, V](fetch: (A, B, C, List[K]) => Future[List[V]]): ClumpSource[(A, B, C, K), V] =
     new ClumpSource(FunctionIdentity(fetch), parameterizeFetchZip(normalize3, fetch3(fetch)))
 
+  /**
+   * Similar to [[sourceZip]] but also accepts 4 extra params
+   */
   def sourceZip[A, B, C, D, K, V](fetch: (A, B, C, D, List[K]) => Future[List[V]]): ClumpSource[(A, B, C, D, K), V] =
     new ClumpSource(FunctionIdentity(fetch), parameterizeFetchZip(normalize4, fetch4(fetch)))
 


### PR DESCRIPTION
Some of these methods are already better explained in the README but this provides a starting point for documenting the project.