### PR TITLE
Add a couple inferred methods and aliases to clump api

### DIFF
--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -122,6 +122,16 @@ object Clump extends Joins with Sources {
   def empty[T]: Clump[T] = value(scala.None)
 
   /**
+   * Alias for [[value]]
+   */
+  def apply[T](value: T): Clump[T] = this.value(value)
+
+  /**
+   * Alias for [[value]]
+   */
+  def apply[T](value: Option[T]): Clump[T] = this.value(value)
+
+  /**
    * The unit method: create a clump whose value has already been resolved to the input
    */
   def value[T](value: T): Clump[T] = future(Future.value(Option(value)))

--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -122,14 +122,14 @@ object Clump extends Joins with Sources {
   def empty[T]: Clump[T] = value(scala.None)
 
   /**
-   * Alias for [[value]]
+   * Alias for [[value]] except that it propagates exceptions inside a clump instance
    */
-  def apply[T](value: T): Clump[T] = this.value(value)
+  def apply[T](value: => T): Clump[T] = this.value(value)
 
   /**
-   * Alias for [[value]]
+   * Alias for [[value]] except that it propagates exceptions inside a clump instance
    */
-  def apply[T](value: Option[T]): Clump[T] = this.value(value)
+  def apply[T](value: => Option[T]): Clump[T] = this.value(value)
 
   /**
    * The unit method: create a clump whose value has already been resolved to the input

--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -124,7 +124,7 @@ object Clump extends Joins with Sources {
   /**
    * Alias for [[value]] except that it propagates exceptions inside a clump instance
    */
-  def apply[T](value: => T): Clump[T] = this.value(value)
+  def apply[T](value: => T): Clump[T] = try { this.value(value) } catch { case e: Throwable => this.exception(e) }
 
   /**
    * The unit method: create a clump whose value has already been resolved to the input

--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -127,11 +127,6 @@ object Clump extends Joins with Sources {
   def apply[T](value: => T): Clump[T] = this.value(value)
 
   /**
-   * Alias for [[value]] except that it propagates exceptions inside a clump instance
-   */
-  def apply[T](value: => Option[T]): Clump[T] = this.value(value)
-
-  /**
    * The unit method: create a clump whose value has already been resolved to the input
    */
   def value[T](value: T): Clump[T] = future(Future.value(Option(value)))

--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -32,9 +32,29 @@ sealed trait Clump[+T] {
   def handle[B >: T](f: PartialFunction[Throwable, Option[B]]): Clump[B] = new ClumpHandle(this, f)
 
   /**
+   * Alias for [[handle]]
+   */
+  def recover[B >: T](f: PartialFunction[Throwable, Option[B]]): Clump[B] = handle(f)
+
+  /**
    * Define a fallback clump to use in the case of specified exceptions
    */
   def rescue[B >: T](f: PartialFunction[Throwable, Clump[B]]): Clump[B] = new ClumpRescue(this, f)
+
+  /**
+   * Alias for [[rescue]]
+   */
+  def recoverWith[B >: T](f: PartialFunction[Throwable, Clump[B]]): Clump[B] = rescue(f)
+
+  /**
+   * On any exception, fallback to a default value
+   */
+  def fallback[B >: T](default: => Option[B]): Clump[B] = handle(PartialFunction(_ => default))
+
+  /**
+   * On any exception, fallback to a default clump
+   */
+  def fallbackTo[B >: T](default: => Clump[B]): Clump[B] = rescue(PartialFunction(_ => default))
 
   /**
    * Alias for [[filter]] used by for-comprehensions
@@ -45,6 +65,11 @@ sealed trait Clump[+T] {
    * Apply a filter to this clump so that the result will only be defined if the predicate function returns true
    */
   def filter[B >: T](f: B => Boolean): Clump[B] = new ClumpFilter(this, f)
+
+  /**
+   * If this clump does not return a value then use the default instead
+   */
+  def orElse[B >: T: ClassTag](default: => B): Clump[B] = new ClumpOrElse(this, Clump.value(default))
 
   /**
    * If this clump does not return a value then use the value from a default clump instead

--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -132,9 +132,19 @@ object Clump extends Joins with Sources {
   def value[T](value: Option[T]): Clump[T] = future(Future.value(value))
 
   /**
+  * Alias for [[value]]
+  */
+  def successful[T](value: T): Clump[T] = this.value(value)
+
+  /**
    * Create a failed clump with the given exception
    */
   def exception[T](exception: Throwable): Clump[T] = future(Future.exception(exception))
+
+  /**
+   * Alias for [[exception]]
+   */
+  def failed[T](exception: Throwable): Clump[T] = this.exception(exception)
 
   /**
    * Create a clump whose value will be the result of the inputted future

--- a/src/main/scala/io/getclump/ClumpSource.scala
+++ b/src/main/scala/io/getclump/ClumpSource.scala
@@ -1,7 +1,6 @@
 package io.getclump
 
 import com.twitter.util.Future
-import scala.collection.generic.CanBuildFrom
 
 class ClumpSource[T, U] private[getclump] (val functionIdentity: FunctionIdentity,
                                               val fetch: Set[T] => Future[Map[T, U]],

--- a/src/test/scala/io/getclump/ClumpApiSpec.scala
+++ b/src/test/scala/io/getclump/ClumpApiSpec.scala
@@ -209,6 +209,30 @@ class ClumpApiSpec extends Spec {
           clumpResult(clump) must throwA[NullPointerException]
         }
       }
+
+      "using a function that recovers using a new value (clump.fallback) on any exception" >> {
+        "exception happens" in {
+          val clump = Clump.exception(new IllegalStateException).fallback(Some(1))
+          clumpResult(clump) mustEqual Some(1)
+        }
+
+        "exception doesn't happen" in {
+          val clump = Clump.value(1).fallback(Some(2))
+          clumpResult(clump) mustEqual Some(1)
+        }
+      }
+
+      "using a function that recovers using a new clump (clump.fallback) on any exception" >> {
+        "exception happens" in {
+          val clump = Clump.exception(new IllegalStateException).fallbackTo(Clump.value(1))
+          clumpResult(clump) mustEqual Some(1)
+        }
+
+        "exception doesn't happen" in {
+          val clump = Clump.value(1).fallbackTo(Clump.value(2))
+          clumpResult(clump) mustEqual Some(1)
+        }
+      }
     }
 
     "can have its result filtered (clump.filter)" in {
@@ -225,6 +249,15 @@ class ClumpApiSpec extends Spec {
     }
 
     "allows to defined a fallback value (clump.orElse)" >> {
+      "undefined" in {
+        clumpResult(Clump.empty.orElse(1)) ==== Some(1)
+      }
+      "defined" in {
+        clumpResult(Clump.value(Some(1)).orElse(2)) ==== Some(1)
+      }
+    }
+
+    "allows to defined a fallback clump (clump.orElse)" >> {
       "undefined" in {
         clumpResult(Clump.empty.orElse(Clump.value(1))) ==== Some(1)
       }


### PR DESCRIPTION
The most useful of these to me is `default`. I want to be able to go:

```scala
for {
  list <- clumpSourceThatReturnsList.get(id).default(Nil)
} yield {
  // code
}
```

instead of having to do this all the time:

```scala
for {
  listOption <- clumpSourceThatReturnsList.get(id).optional
} yield {
  val list = listOption.getOrElse(Nil)
  // code
}
```