### PR TITLE
limit the default max batch size

### DIFF
--- a/src/main/scala/io/getclump/ClumpSource.scala
+++ b/src/main/scala/io/getclump/ClumpSource.scala
@@ -2,7 +2,7 @@ package io.getclump
 
 
 class ClumpSource[T, U] private[getclump] (val fetch: List[T] => Future[Map[T, U]],
-                                           val maxBatchSize: Int = Int.MaxValue,
+                                           val maxBatchSize: Int = 100,
                                            val _maxRetries: PartialFunction[Throwable, Int] = PartialFunction.empty) {
 
   /**

--- a/src/test/scala/io/getclump/ClumpSourceSpec.scala
+++ b/src/test/scala/io/getclump/ClumpSourceSpec.scala
@@ -84,4 +84,9 @@ class ClumpSourceSpec extends Spec {
       verifyNoMoreInteractions(repo)
     }
   }
+  
+  "limits the batch size to 100 by default" in new Context {
+    val source = Clump.source(repo.fetch _)
+    source.maxBatchSize mustEqual 100
+  }
 }


### PR DESCRIPTION
@williamboxhall @stevenheidel 

I spent many days trying to identify the cause for a production issue and in the end the main problem was the size of the batch requests to memcached. The system was making requests for batches with thousands of keys.

We need to avoid letting users run into similar problems. This pull request sets the default `maxBatchSize` to `100`. Another alternative would be make the `maxBatchSize` required when creating a `ClumpSource`.