### PR TITLE
Optimize ClumpContext execution algorithm to fetch in parallel at diferent levels of composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,13 +510,13 @@ This section explains how Clump works under the hood.
 
 The codebase is relatively small. The only type explicitly exposed to the user is ```Clump```, but internally there are four in total:
 
-[Clump](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/Clump.scala) - Defines the public interface of Clump and represents the abstract syntactic tree (AST) for the compositions.
+[Clump](https://github.com/getclump/clump/blob/master/src/main/scala/io/getclump/Clump.scala) - Defines the public interface of Clump and represents the abstract syntactic tree (AST) for the compositions.
 
-[ClumpSource](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/ClumpSource.scala) - Represents the external systems' batched interfaces.
+[ClumpSource](https://github.com/getclump/clump/blob/master/src/main/scala/io/getclump/ClumpSource.scala) - Represents the external systems' batched interfaces.
 
-[ClumpFetcher](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/ClumpFetcher.scala) - It has the logic to fetch from a ```ClumpSource```, maintains the implicit cache and implements the logic to retry failed fetches.
+[ClumpFetcher](https://github.com/getclump/clump/blob/master/src/main/scala/io/getclump/ClumpFetcher.scala) - It has the logic to fetch from a ```ClumpSource```, maintains the implicit cache and implements the logic to retry failed fetches.
 
-[ClumpContext](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/ClumpContext.scala) - It is the execution model engine created automatically for each execution. It keeps the state by using a collection of ```ClumpFetcher```s.
+[ClumpContext](https://github.com/getclump/clump/blob/master/src/main/scala/io/getclump/ClumpContext.scala) - It is the execution model engine created automatically for each execution. It keeps the state by using a collection of ```ClumpFetcher```s.
 
 Take some time to read the code of these classes. It will help to have a broader view and understand the explanation that follows.
 
@@ -546,7 +546,7 @@ val usersSource = Clump.source(usersService.fetch _)(_.id)
 val tracksSource = Clump.source(tracksService.fetch _)(_.id)
 ```
 
-The ```ClumpSource``` instances are created using one of the shortcuts that the ```Clump``` object [provides](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/Clump.scala#L112). They don't hold any state and allow to create Clump instances representing the [fetch](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/ClumpSource.scala#L18). Clump uses the source's identity to group requests and perform batched fetches, so it is __not__ possible to have multiple instances of the same source within a clump composition and execution.
+The ```ClumpSource``` instances are created using one of the shortcuts that the ```Clump``` object provides. They don't hold any state and allow to create Clump instances representing the fetch. Clump uses the source's identity to group requests and perform batched fetches, so it is __not__ possible to have multiple instances of the same source within a clump composition and execution.
 
 ## Composition
 
@@ -557,7 +557,7 @@ val clump: Clump[List[EnrichedTrack]] =
     }
 ```
 
-The ```traverse``` method is used as a [shortcut](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/Clump.scala#L64) for ```map``` and then ```collect```, so this code could be rewritten as follows:
+The ```traverse``` method is used as a shortcut for ```map``` and then ```collect```, so this code could be rewritten as follows:
 
 ```scala
 val clump: Clump[List[EnrichedTrack]] =
@@ -589,23 +589,23 @@ The for-comprehension is actually just syntactic sugar using ```map``` and ```fl
 
 There are three methods being used in this composition:
 
-1. ```get``` [creates](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/ClumpSource.scala#L17) a ```ClumpFetch``` instances that is the AST element [representing the fetch](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/Clump.scala#L131). It doesn't trigger the actual fetch, only uses the ```ClumpFetcher``` instance to produce a ```Future``` that will be [executed by](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/ClumpFetcher.scala#L17) the ```ClumpContext``` when the execution is triggered. 
+1. ```get``` creates a ```ClumpFetch``` instances that is the AST element representing the fetch. It doesn't trigger the actual fetch, only uses the ```ClumpFetcher``` instance to produce a ```Future``` that will be executed by the ```ClumpContext``` when the execution is triggered.
 
-2. ```flatMap``` creates a ```ClumpFlatMap``` instance [representing the operation](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/Clump.scala#L168). It just [composes a new future](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/Clump.scala#L174) that is based on the result of the initial Clump and the result of the nested Clump.
+2. ```flatMap``` creates a ```ClumpFlatMap``` instance representing the operation. It just composes a new future that is based on the result of the initial Clump and the result of the nested Clump.
 
-3. ```map``` creates a ```ClumpMap``` instance [representing the map operation](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/Clump.scala#L161). It [composes a new future](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/Clump.scala#L164) by applying the specified transformation.
+3. ```map``` creates a ```ClumpMap``` instance representing the map operation. It composes a new future by applying the specified transformation.
 
 ## Execution
 
 Now comes the most important part. Until now, the compositions only create ```Clump*``` instances to represent the operations and produce futures that will be fulfilled when the execution is triggered. You probably have noticed that the Clump instances define three things:
 
-1. ```result``` that has the ```Future``` [result](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/Clump.scala#L47) for the operation
-2. ```upstream``` that [returns](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/Clump.scala#L45) the upstream Clump instances that were used as the basis for the composition
-3. ```downstream``` that [returns](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/Clump.scala#L46) the downstream Clump instances created as a result of the operation
+1. ```result``` that has the ```Future``` result for the operation
+2. ```upstream``` that returns the upstream Clump instances that were used as the basis for the composition
+3. ```downstream``` that returns the downstream Clump instances created as a result of the operation
 
 Note that ```downstream``` returns a ```Future[List[Clump[_]]]```, while ```upstream``` returns a ```List[Clump[_]]``` directly. This happens because ```downstream``` produces Clump instances that are available only after the ```upstream``` execution.
 
-These methods are used by the ```ClumpContext``` to apply the execution model. It has a [collection](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/ClumpContext.scala#L10) with all ```ClumpFetcher``` instances in the composition.
+These methods are used by the ```ClumpContext``` to apply the execution model. It has a collection with all ```ClumpFetcher``` instances in the composition.
 
 This is the code that triggers the execution:
 
@@ -613,17 +613,17 @@ This is the code that triggers the execution:
 val tracks: Future[List[Track]] = clump.list
 ```
 
-The ```list``` method is just a [shortcut](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/Clump.scala#L35) to ease getting the value of Clump instances that have a collection. The actual execution is triggered by the ```get``` [method](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/Clump.scala#L38). It flushes the context and returns the Clump's result.
+The ```list``` method is just a shortcut to ease getting the value of Clump instances that have a collection. The actual execution is triggered by the ```get``` method. It flushes the context and returns the Clump's result.
 
-The [context flush](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/ClumpContext.scala#L20) is a recursive function that performs simple steps:
+The context flush is a mutually recursive function that uses the following steps:
 
-* If there aren't Clump instances to be fetched, [stop the recursion](https://github.com/getclump/clump/blob/v0.0.7/src/main/scala/io/getclump/ClumpContext.scala#L22);
-* If there are Clump instances to be fetched
-  * Flush all the upstream instances of the current clumps;
-  * Perform all the fetches among the current Clump instances being executed.
-  * Flush all the downstream instances, since the pre-requisite to run the downstream is fulfilled (upstream already flushed). Note that the difference from the ```upstream``` flush is due the fact that ```downstream``` returns a future, but the semantic is the same.
+* Retrieve a list of visible Clump instances. Recall  that ```upstream``` returns a ```List[Clump[_]]``` directly. All the visible Clump instances are therefore retrieved by recursively getting a list of upstream Clumps, then all the upstream Clumps from each Clump in that list, and so on.
+* Perform all the fetches among the visible Clump instances. This batches together calls to the same ```ClumpSource``` and also performs all batch flushes in parallel.
+* Finally, flush the downstream instances
+  * The rule is that all upstream instances must be flushed before any of the downstream instances. The only Clump instances that fulfill this requirement at this point are the downstream instances of the Clumps at the deepest level of the visible traversal. Flush these first.
+  * As each level of downstream instances is flushed, move up a level and flush again since the pre-requisite must be fulfilled. (The upstream have already been flushed in the first step, and any downstream Clumps from the current Clump's upstream instances would have been at a deeper level of composition and therefore have been flushed already).
 
-You could consider this a depth-first, upstream-first traversal of the Clump graph.
+You could consider this a upstream-first traversal of the Clump graph.
 
 In case you are wondering why we need this upstream mechanism since we have the Clump instance at hand and could start the execution from it: actually the instance used to trigger the execution isn't the "root" of the composition. For instance:
 
@@ -665,20 +665,16 @@ get--> |   (line 2)   |                                   +-------> Empty
 The steps to execute this composition happen as follows:
 
 * The execution is triggered by the ```get``` method on the ```ClumpFlatMap``` instance
-* The flush of ```ClumpFlatMap``` starts
-  * ```ClumpFlatMap``` upstream is flushed
-    * The flush of ```ClumpFetch``` starts
-      * Upstream is flushed and returns immediately (empty)
-      * The fetch is executed to fulfill the prerequisites to the downstream flush (upstream + fetch)
-      * Downstream is flushed and returns immediately (empty)
-  * ```ClumpFlatMap``` downstream is flushed
-    * The flush of ```ClumpMap``` starts
-      * Upstream is flushed
-        * The flush of the second ```ClumpFetch``` starts
-          * Upstream is flushed and returns immediately (empty)
-          * The fetch is executed
-          * Downstream is flushed and returns immediately (empty)
-      * Downstream is flushed and returns immediately (empty)
+* The only visible Clumps are ```ClumpFlatMap``` and ```ClumpFetch```
+* The fetch is executed
+* Downstream instances are flushed starting at the deepest level
+  * Downstream of ```ClumpFetch``` is empty and returns immediately
+  * Downstream of ```ClumpFlatMap``` can now be flushed because the entire upstream path was already flushed
+    * Visibility has increased, so now the visible Clumps are ```ClumpMap``` and ```ClumpFetch```
+    * The fetch is executed
+    * Downstream instances are flushed starting at the deepest level
+      * Downstream of ```ClumpFetch``` is empty and returns immediately
+      * Downstream of ```ClumpMap``` is empty and returns immediately
 
 Note that this example has only one Clump instance per flush phase, but normally there are multiple instances. This is what allows Clump to batch requests that are in the same flush phase.
 
@@ -733,7 +729,7 @@ The project was initially built using SoundCloud's [Hacker Time](https://develop
 
 # Versioning #
 
-Clump adheres to Semantic Versioning 2.0.0. If there is a violation of this scheme, report it as a bug.Specifically, if a patch or minor version is released and breaks backward compatibility, that version should be immediately yanked and/or a new version should be immediately released that restores compatibility. Any change that breaks the public API will only be introduced at a major-version release.
+Clump adheres to Semantic Versioning 2.0.0. If there is a violation of this scheme, report it as a bug. Specifically, if a patch or minor version is released and breaks backward compatibility, that version should be immediately yanked and/or a new version should be immediately released that restores compatibility. Any change that breaks the public API will only be introduced at a major-version release.
 
 # License #
 

--- a/STITCH.md
+++ b/STITCH.md
@@ -99,14 +99,3 @@ It is common to have an object graph where the same resource is used in multiple
 
 This mechanism is not present in Stitch, but the its execution model is able to group deep nested fetches and thus reduce the impact of the missing cache.
 
-5. Execution model
-==================
-
-Stitch has an execution model capable of inspecting the AST definition and prepare an execution plan to allow batching. It also has logic to apply simplifications on the execution plan.
-
-Clump has a simpler execution model that favors parallelism. Basically, it uses four steps:
-
-1. Find the "roots" of the composition
-2. Expand the composition starting from the roots and register the pending fetches
-3. Flush all pending fetches in parallel for each source
-4. If there are nested structures, go back to 2 using them as the roots. If not, return the clump's value.

--- a/src/main/scala/io/getclump/ClumpContext.scala
+++ b/src/main/scala/io/getclump/ClumpContext.scala
@@ -42,7 +42,7 @@ private[getclump] final class ClumpContext {
   }
 
   // Flush all the ClumpFetch instances in a list of clumps, calling their associated fetch functions in parallel if possible
-  private[this] def flushFetches(clumps: List[Clump[_]]): Future[Unit] = {
+  private[this] def flushFetches(clumps: List[Clump[_]]) = {
     val fetches = filterFetches(clumps)
     val byFetcher = fetches.groupBy(fetch => fetcherFor(fetch.source))
     for ((fetcher, fetches) <- byFetcher)
@@ -50,13 +50,13 @@ private[getclump] final class ClumpContext {
     Future.sequence(byFetcher.keys.map(_.flush)).map(_ => ())
   }
 
-  private[this] def filterFetches(clumps: List[Clump[_]]): List[ClumpFetch[Any, Any]] =
+  private[this] def filterFetches(clumps: List[Clump[_]]) =
     clumps.collect {
       case clump: ClumpFetch[_, _] =>
         clump.asInstanceOf[ClumpFetch[Any, Any]]
     }
 
-  private[this] def fetcherFor(source: ClumpSource[_, _]): ClumpFetcher[Any, Any] =
+  private[this] def fetcherFor(source: ClumpSource[_, _]) =
     synchronized {
       fetchers.getOrElseUpdate(source, new ClumpFetcher(source))
         .asInstanceOf[ClumpFetcher[Any, Any]]

--- a/src/main/scala/io/getclump/ClumpContext.scala
+++ b/src/main/scala/io/getclump/ClumpContext.scala
@@ -7,40 +7,56 @@ private[getclump] final class ClumpContext {
   private[this] val fetchers =
     new HashMap[ClumpSource[_, _], ClumpFetcher[_, _]]()
 
-  def flush(clumps: List[Clump[_]]): Future[Unit] =
+  def flush(clumps: List[Clump[_]]): Future[Unit] = {
+    // 1. Get a list of all visible clumps grouped by level of composition
+    val clumpsByLevel = getClumpsByLevel(clumps)
+
+    // 2. Flush the fetches from all the visible clumps
+    flushFetches(clumpsByLevel.flatten).flatMap { _ =>
+      // 3. Walk through the downstream clumps as well, starting at the deepest level
+      flushDownstreamByLevel(clumpsByLevel.reverse)
+    }
+  }
+
+  // Unfold all visible (ie. upstream) clumps
+  private[this] def getClumpsByLevel(clumps: List[Clump[_]]): List[List[Clump[_]]] = {
     clumps match {
+      case Nil => Nil
+      case _ => clumps :: getClumpsByLevel(clumps.flatMap(_.upstream))
+    }
+  }
+
+  private[this] def flushDownstreamByLevel(levels: List[List[Clump[_]]]): Future[Unit] = {
+    levels match {
       case Nil => Future.successful(())
-      case _ =>
-        flushUpstream(clumps).flatMap { _ =>
-          flushFetches(clumps).flatMap { _ =>
-            flushDownstream(clumps)
+      case head :: tail =>
+        // 1. Resolve the downstream clumps (will succeed because deeper downstream clumps have already been resolved)
+        Future.sequence(head.map(_.downstream)).flatMap { res =>
+          // 2. Flush the resulting clumps, thus completely resolving this subtree of the composition
+          flush(res.flatten).flatMap { _ =>
+            // 3. Move up one level of composition and repeat this process
+            flushDownstreamByLevel(tail)
           }
         }
     }
+  }
 
-  private[this] def flushUpstream(clumps: List[Clump[_]]) =
-    flush(clumps.map(_.upstream).flatten)
-
-  private[this] def flushDownstream(clumps: List[Clump[_]]) =
-    Future.sequence(clumps.map(_.downstream)).flatMap { down =>
-      flush(down.flatten.toList)
-    }
-
-  private[this] def flushFetches(clumps: List[Clump[_]]) = {
+  // Flush all the ClumpFetch instances in a list of clumps, calling their associated fetch functions in parallel if possible
+  private[this] def flushFetches(clumps: List[Clump[_]]): Future[Unit] = {
     val fetches = filterFetches(clumps)
     val byFetcher = fetches.groupBy(fetch => fetcherFor(fetch.source))
     for ((fetcher, fetches) <- byFetcher)
       fetches.foreach(_.attachTo(fetcher))
-    Future.sequence(byFetcher.keys.map(_.flush).toSeq)
+    Future.sequence(byFetcher.keys.map(_.flush)).map(_ => ())
   }
 
-  private[this] def filterFetches(clumps: List[Clump[_]]) =
+  private[this] def filterFetches(clumps: List[Clump[_]]): List[ClumpFetch[Any, Any]] =
     clumps.collect {
       case clump: ClumpFetch[_, _] =>
         clump.asInstanceOf[ClumpFetch[Any, Any]]
     }
 
-  private[this] def fetcherFor(source: ClumpSource[_, _]) =
+  private[this] def fetcherFor(source: ClumpSource[_, _]): ClumpFetcher[Any, Any] =
     synchronized {
       fetchers.getOrElseUpdate(source, new ClumpFetcher(source))
         .asInstanceOf[ClumpFetcher[Any, Any]]

--- a/src/main/scala/io/getclump/package-twitter.scala.tmpl
+++ b/src/main/scala/io/getclump/package-twitter.scala.tmpl
@@ -24,7 +24,7 @@ package object getclump {
   implicit class FutureCompanionBridge(val companion: Future.type) extends AnyVal {
     def successful[T](value: T) = Future.value(value)
     def failed[T](exception: Throwable) = Future.exception[T](exception)
-    def sequence[T](futures: Seq[Future[T]]) = Future.collect(futures)
+    def sequence[T](futures: Iterable[Future[T]]) = Future.collect(futures.toSeq).map(_.toList)
   }
 
   private[getclump] def awaitResult[T](future: Future[T]) =

--- a/src/test/scala/io/getclump/ClumpExecutionSpec.scala
+++ b/src/test/scala/io/getclump/ClumpExecutionSpec.scala
@@ -40,6 +40,23 @@ class ClumpExecutionSpec extends Spec {
       source2Fetches mustEqual List(Set(3, 4))
     }
 
+    "for multiple clumps collected into only one clump" in new Context {
+      val clump = Clump.collect(source1.get(1), source1.get(2), source2.get(3), source2.get(4))
+
+      clumpResult(clump) mustEqual Some(List(10, 20, 30, 40))
+      source1Fetches mustEqual List(Set(1, 2))
+      source2Fetches mustEqual List(Set(3, 4))
+    }
+
+    "for clumps created inside nested flatmaps" in new Context {
+      val clump1 = Clump.value(1).flatMap(source1.get(_)).flatMap(source2.get(_))
+      val clump2 = Clump.value(2).flatMap(source1.get(_)).flatMap(source2.get(_))
+
+      clumpResult(Clump.collect(clump1, clump2)) mustEqual Some(List(100, 200))
+      source1Fetches mustEqual List(Set(1, 2))
+      source2Fetches mustEqual List(Set(20, 10))
+    }
+
     "for clumps composed using for comprehension" >> {
 
       "one level" in new Context {

--- a/src/test/scala/io/getclump/ClumpExecutionSpec.scala
+++ b/src/test/scala/io/getclump/ClumpExecutionSpec.scala
@@ -149,7 +149,7 @@ class ClumpExecutionSpec extends Spec {
 
     val future: Future[Option[(Int, Int)]] = clump.get
 
-    promises.size mustEqual 2
+    promisesIterator.hasNext must beFalse
   }
 
   "executes 2 joined clumps in parallel at different levels of composition" in new Context {
@@ -164,7 +164,7 @@ class ClumpExecutionSpec extends Spec {
 
     val future: Future[Option[(Int, Int)]] = clump.get
 
-    promises.size mustEqual 2
+    promisesIterator.hasNext must beFalse
   }
 
   "executes 3 joined clumps in parallel" in new Context {
@@ -179,7 +179,7 @@ class ClumpExecutionSpec extends Spec {
 
     val future: Future[Option[(Int, Int, Int)]] = clump.get
 
-    promises.size mustEqual 3
+    promisesIterator.hasNext must beFalse
   }
 
   "short-circuits the computation in case of a failure" in new Context {


### PR DESCRIPTION
Motivating example from our code:

```scala
Clump.join(
  profiles.get(123).optional,
  companies.get(456)
)
```

You'd expect this to make a call to `profiles` and `companies` at the same time. However, because they are at different levels the current algorithm waits until after `profiles` is done before getting `companies`.

This changes the flush method to walk to the bottom of the entire upstream path and do all the fetches at once, then walk back up the downstreams one by one resolving them in order. This means `profiles` and `companies` will now be executed in parallel as expected, and doing any number of simple .maps or .optionals on a fetch will not affect its parallelism. This also means Clumps joined 3 ways will happen in parallel as well, which I don't believe was the case before because of the nested ClumpJoin from how Joins.scala works.