### PR TITLE
Allow custom Execution Context to be passed in

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -62,7 +62,7 @@ object Build extends Build {
     .settings(name := "clump-scala")
     .settings(commonSettings: _*)
     .settings(target <<= target(_ / "clump-scala"))
-//    .aggregate(clumpTwitter)
+    .aggregate(clumpTwitter)
 
   lazy val clumpTwitter = Project(id = "clump-twitter", base = file("."))
     .settings(name := "clump-twitter")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -62,7 +62,7 @@ object Build extends Build {
     .settings(name := "clump-scala")
     .settings(commonSettings: _*)
     .settings(target <<= target(_ / "clump-scala"))
-    .aggregate(clumpTwitter)
+//    .aggregate(clumpTwitter)
 
   lazy val clumpTwitter = Project(id = "clump-twitter", base = file("."))
     .settings(name := "clump-twitter")

--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -81,24 +81,24 @@ sealed trait Clump[+T] {
    * A utility method for automatically unwrapping the underlying value
    * @throws NoSuchElementException if the underlying value is not defined
    */
-  def apply()(implicit executionContext: ExecutionContext): Future[T] = get.map(_.get)
+  def apply()(implicit ec: ExecutionContext): Future[T] = get.map(_.get)
 
   /**
    * Get the result of the clump or provide a fallback value in the case where the result is not defined
    */
-  def getOrElse[B >: T](default: => B)(implicit executionContext: ExecutionContext): Future[B] = get.map(_.getOrElse(default))
+  def getOrElse[B >: T](default: => B)(implicit ec: ExecutionContext): Future[B] = get.map(_.getOrElse(default))
 
   /**
    * If the underlying value is a list, then this will return Nil instead of None when the result is not defined
    */
-  def list[B >: T](implicit cbf: CanBuildFrom[Nothing, Nothing, B], executionContext: ExecutionContext): Future[B] =
+  def list[B >: T](implicit cbf: CanBuildFrom[Nothing, Nothing, B], ec: ExecutionContext): Future[B] =
     get.map(_.getOrElse(cbf().result()))
 
   /**
    * Trigger execution of a clump. The result will not be defined if any of the clump sources returned less elements
    * than requested.
    */
-  def get(implicit executionContext: ExecutionContext): Future[Option[T]] =
+  def get(implicit ec: ExecutionContext): Future[Option[T]] =
     new ClumpContext()
       .flush(List(this))
       .flatMap { _ =>
@@ -106,8 +106,8 @@ sealed trait Clump[+T] {
       }
 
   protected[getclump] def upstream: List[Clump[_]] = List.empty[Clump[_]]
-  protected[getclump] def downstream(implicit executionContext: ExecutionContext): Future[Option[Clump[_]]] = Future.successful(None)
-  protected[getclump] def result(implicit executionContext: ExecutionContext): Future[Option[T]]
+  protected[getclump] def downstream(implicit ec: ExecutionContext): Future[Option[Clump[_]]] = Future.successful(None)
+  protected[getclump] def result(implicit ec: ExecutionContext): Future[Option[T]]
 }
 
 object Clump extends Joins with Sources {
@@ -150,7 +150,7 @@ object Clump extends Joins with Sources {
   /**
    * Create a clump whose value will be the result of the inputted future
    */
-  def future[T: ClassTag](future: Future[T])(implicit executionContext: ExecutionContext): Clump[T] = new ClumpFuture(future.map(Option(_)))
+  def future[T: ClassTag](future: Future[T])(implicit ec: ExecutionContext): Clump[T] = new ClumpFuture(future.map(Option(_)))
 
   /**
    * Create a clump whose value will be the result of the inputted future if it is defined
@@ -192,22 +192,22 @@ object Clump extends Joins with Sources {
 }
 
 private[getclump] class ClumpFuture[T](val future: Future[Option[T]]) extends Clump[T] {
-  override def downstream(implicit executionContext: ExecutionContext) = future.map(_ => None).recover {
+  override def downstream(implicit ec: ExecutionContext) = future.map(_ => None).recover {
     case _ => None
   }
-  override def result(implicit executionContext: ExecutionContext) = future
+  override def result(implicit ec: ExecutionContext) = future
 }
 
 private[getclump] class ClumpFetch[T, U](input: T, val source: ClumpSource[T, U]) extends Clump[U] {
   private val promise = Promise[Option[U]]
-  override def result(implicit executionContext: ExecutionContext) = promise.future
-  def attachTo(fetcher: ClumpFetcher[T, U])(implicit executionContext: ExecutionContext) =
+  override def result(implicit ec: ExecutionContext) = promise.future
+  def attachTo(fetcher: ClumpFetcher[T, U])(implicit ec: ExecutionContext) =
     fetcher.get(input).onComplete(promise.complete)
 }
 
 private[getclump] class ClumpJoin[A, B](a: Clump[A], b: Clump[B]) extends Clump[(A, B)] {
   override val upstream = List(a, b)
-  override def result(implicit executionContext: ExecutionContext) =
+  override def result(implicit ec: ExecutionContext) =
     a.result.zip(b.result)
       .map {
         case (Some(valueA), Some(valueB)) => Some((valueA, valueB))
@@ -218,7 +218,7 @@ private[getclump] class ClumpJoin[A, B](a: Clump[A], b: Clump[B]) extends Clump[
 private[getclump] class ClumpCollect[T, C[_] <: Iterable[_]](clumps: C[Clump[T]])(implicit cbf: CanBuildFrom[C[Clump[T]], T, C[T]]) extends Clump[C[T]] {
   override val upstream =
     clumps.toList.asInstanceOf[List[Clump[T]]]
-  override def result(implicit executionContext: ExecutionContext) =
+  override def result(implicit ec: ExecutionContext) =
     Future
       .sequence(upstream.map(_.result))
       .map(_.flatten)
@@ -228,17 +228,18 @@ private[getclump] class ClumpCollect[T, C[_] <: Iterable[_]](clumps: C[Clump[T]]
 
 private[getclump] class ClumpMap[T, U](clump: Clump[T], f: T => U) extends Clump[U] {
   override val upstream = List(clump)
-  override def result(implicit executionContext: ExecutionContext) =
+  override def result(implicit ec: ExecutionContext) =
     clump.result.map(_.map(f))
 }
 
 private[getclump] class ClumpFlatMap[T, U](clump: Clump[T], f: T => Clump[U]) extends Clump[U] {
   override val upstream = List(clump)
-  private def partial(implicit executionContext: ExecutionContext) =
-    clump.result.map(_.map(f))
-  override def downstream(implicit executionContext: ExecutionContext) =
+  private val wrapped = RunOnce(f)
+  private def partial(implicit ec: ExecutionContext) =
+    clump.result.map(_.map(wrapped))
+  override def downstream(implicit ec: ExecutionContext) =
     partial
-  override def result(implicit executionContext: ExecutionContext) =
+  override def result(implicit ec: ExecutionContext) =
     partial.flatMap {
       case Some(clump) => clump.result
       case None        => Future.successful(None)
@@ -247,43 +248,45 @@ private[getclump] class ClumpFlatMap[T, U](clump: Clump[T], f: T => Clump[U]) ex
 
 private[getclump] class ClumpHandle[T](clump: Clump[T], f: PartialFunction[Throwable, Option[T]]) extends Clump[T] {
   override val upstream = List(clump)
-  override def result(implicit executionContext: ExecutionContext) =
+  override def result(implicit ec: ExecutionContext) =
     clump.result.recover(f)
 }
 
 private[getclump] class ClumpRescue[T](clump: Clump[T], rescue: PartialFunction[Throwable, Clump[T]]) extends Clump[T] {
   override val upstream = List(clump)
-  private def partial(implicit executionContext: ExecutionContext) =
+  private val wrapped = RunOnce(rescue)
+  private def partial(implicit ec: ExecutionContext) =
     clump.result.map(Clump.value).recover {
-      case exception if (rescue.isDefinedAt(exception)) => rescue(exception)
+      case exception if (rescue.isDefinedAt(exception)) => wrapped(exception)
       case exception                                    => Clump.exception(exception)
     }
-  override def downstream(implicit executionContext: ExecutionContext) =
+  override def downstream(implicit ec: ExecutionContext) =
     partial.map(Some(_))
-  override def result(implicit executionContext: ExecutionContext) =
+  override def result(implicit ec: ExecutionContext) =
     partial.flatMap(_.result)
 }
 
 private[getclump] class ClumpFilter[T](clump: Clump[T], f: T => Boolean) extends Clump[T] {
   override val upstream = List(clump)
-  override def result(implicit executionContext: ExecutionContext) =
+  override def result(implicit ec: ExecutionContext) =
     clump.result.map(_.filter(f))
 }
 
 private[getclump] class ClumpOrElse[T](clump: Clump[T], default: => Clump[T]) extends Clump[T] {
   override val upstream = List(clump)
-  private def partial(implicit executionContext: ExecutionContext) =
+  private val wrapped = RunOnce { _: Unit => default }
+  private def partial(implicit ec: ExecutionContext) =
     clump.result.map {
       case Some(value) => Clump.value(value)
-      case None        => default
+      case None        => wrapped(())
     }
-  override def downstream(implicit executionContext: ExecutionContext) =
+  override def downstream(implicit ec: ExecutionContext) =
     partial.map(Some(_))
-  override def result(implicit executionContext: ExecutionContext) =
+  override def result(implicit ec: ExecutionContext) =
     partial.flatMap(_.result)
 }
 
 private[getclump] class ClumpOptional[T](clump: Clump[T]) extends Clump[Option[T]] {
   override val upstream = List(clump)
-  override def result(implicit executionContext: ExecutionContext) = clump.result.map(Some(_))
+  override def result(implicit ec: ExecutionContext) = clump.result.map(Some(_))
 }

--- a/src/main/scala/io/getclump/ClumpContext.scala
+++ b/src/main/scala/io/getclump/ClumpContext.scala
@@ -42,7 +42,7 @@ private[getclump] final class ClumpContext {
   }
 
   // Flush all the ClumpFetch instances in a list of clumps, calling their associated fetch functions in parallel if possible
-  private[this] def flushFetches(clumps: List[Clump[_]]): Future[Unit] = {
+  private[this] def flushFetches(clumps: List[Clump[_]]) = {
     val fetches = filterFetches(clumps)
     val byFetcher = fetches.groupBy(fetch => fetcherFor(fetch.source))
     for ((fetcher, fetches) <- byFetcher)
@@ -50,13 +50,13 @@ private[getclump] final class ClumpContext {
     Future.sequence(byFetcher.keys.map(_.flush)).map(_ => ())
   }
 
-  private[this] def filterFetches(clumps: List[Clump[_]]): List[ClumpFetch[Any, Any]] =
+  private[this] def filterFetches(clumps: List[Clump[_]]) =
     clumps.collect {
       case clump: ClumpFetch[_, _] =>
         clump.asInstanceOf[ClumpFetch[Any, Any]]
     }
 
-  private[this] def fetcherFor(source: ClumpSource[_, _]): ClumpFetcher[Any, Any] =
+  private[this] def fetcherFor(source: ClumpSource[_, _]) =
     synchronized {
       fetchers.getOrElseUpdate(source, new ClumpFetcher(source))
         .asInstanceOf[ClumpFetcher[Any, Any]]

--- a/src/main/scala/io/getclump/ClumpContext.scala
+++ b/src/main/scala/io/getclump/ClumpContext.scala
@@ -8,7 +8,7 @@ private[getclump] final class ClumpContext {
   private[this] val fetchers =
     new HashMap[ClumpSource[_, _], ClumpFetcher[_, _]]()
 
-  def flush(clumps: List[Clump[_]])(implicit executionContext: ExecutionContext): Future[Unit] = {
+  def flush(clumps: List[Clump[_]])(implicit ec: ExecutionContext): Future[Unit] = {
     // 1. Get a list of all visible clumps grouped by level of composition
     val clumpsByLevel = getClumpsByLevel(clumps)
 
@@ -27,7 +27,7 @@ private[getclump] final class ClumpContext {
     }
   }
 
-  private[this] def flushDownstreamByLevel(levels: List[List[Clump[_]]])(implicit executionContext: ExecutionContext): Future[Unit] = {
+  private[this] def flushDownstreamByLevel(levels: List[List[Clump[_]]])(implicit ec: ExecutionContext): Future[Unit] = {
     levels match {
       case Nil => Future.successful(())
       case head :: tail =>
@@ -43,7 +43,7 @@ private[getclump] final class ClumpContext {
   }
 
   // Flush all the ClumpFetch instances in a list of clumps, calling their associated fetch functions in parallel if possible
-  private[this] def flushFetches(clumps: List[Clump[_]])(implicit executionContext: ExecutionContext) = {
+  private[this] def flushFetches(clumps: List[Clump[_]])(implicit ec: ExecutionContext) = {
     val fetches = filterFetches(clumps)
     val byFetcher = fetches.groupBy(fetch => fetcherFor(fetch.source))
     for ((fetcher, fetches) <- byFetcher)

--- a/src/main/scala/io/getclump/ClumpContext.scala
+++ b/src/main/scala/io/getclump/ClumpContext.scala
@@ -7,40 +7,56 @@ private[getclump] final class ClumpContext {
   private[this] val fetchers =
     new HashMap[ClumpSource[_, _], ClumpFetcher[_, _]]()
 
-  def flush(clumps: List[Clump[_]]): Future[Unit] =
+  def flush(clumps: List[Clump[_]]): Future[Unit] = {
+    // 1. Get a list of all visible clumps grouped by level of composition
+    val clumpsByLevel = getClumpsByLevel(clumps)
+
+    // 2. Flush the fetches from all the visible clumps
+    flushFetches(clumpsByLevel.flatten).flatMap { _ =>
+      // 3. Walk through the downstream clumps as well, starting at the deepest level
+      flushDownstreamByLevel(clumpsByLevel.reverse)
+    }
+  }
+
+  // Unfold all visible (ie. upstream) clumps
+  private[this] def getClumpsByLevel(clumps: List[Clump[_]]): List[List[Clump[_]]] = {
     clumps match {
+      case Nil => Nil
+      case _ => clumps :: getClumpsByLevel(clumps.flatMap(_.upstream))
+    }
+  }
+
+  private[this] def flushDownstreamByLevel(levels: List[List[Clump[_]]]): Future[Unit] = {
+    levels match {
       case Nil => Future.successful(())
-      case _ =>
-        flushUpstream(clumps).flatMap { _ =>
-          flushFetches(clumps).flatMap { _ =>
-            flushDownstream(clumps)
+      case head :: tail =>
+        // 1. Resolve the downstream clumps (will succeed because deeper downstream clumps have already been resolved)
+        Future.sequence(head.map(_.downstream)).flatMap { res =>
+          // 2. Flush the resulting clumps, thus completely resolving this subtree of the composition
+          flush(res.flatten).flatMap { _ =>
+            // 3. Move up one level of composition and repeat this process
+            flushDownstreamByLevel(tail)
           }
         }
     }
+  }
 
-  private[this] def flushUpstream(clumps: List[Clump[_]]) =
-    flush(clumps.map(_.upstream).flatten)
-
-  private[this] def flushDownstream(clumps: List[Clump[_]]) =
-    Future.sequence(clumps.map(_.downstream)).flatMap { down =>
-      flush(down.flatten.toList)
-    }
-
-  private[this] def flushFetches(clumps: List[Clump[_]]) = {
+  // Flush all the ClumpFetch instances in a list of clumps, calling their associated fetch functions in parallel if possible
+  private[this] def flushFetches(clumps: List[Clump[_]]): Future[Unit] = {
     val fetches = filterFetches(clumps)
     val byFetcher = fetches.groupBy(fetch => fetcherFor(fetch.source))
     for ((fetcher, fetches) <- byFetcher)
       fetches.foreach(_.attachTo(fetcher))
-    Future.sequence(byFetcher.keys.map(_.flush).toSeq)
+    Future.sequence(byFetcher.keys.map(_.flush)).map(_ => ())
   }
 
-  private[this] def filterFetches(clumps: List[Clump[_]]) =
+  private[this] def filterFetches(clumps: List[Clump[_]]): List[ClumpFetch[Any, Any]] =
     clumps.collect {
       case clump: ClumpFetch[_, _] =>
         clump.asInstanceOf[ClumpFetch[Any, Any]]
     }
 
-  private[this] def fetcherFor(source: ClumpSource[_, _]) =
+  private[this] def fetcherFor(source: ClumpSource[_, _]): ClumpFetcher[Any, Any] =
     synchronized {
       fetchers.getOrElseUpdate(source, new ClumpFetcher(source))
         .asInstanceOf[ClumpFetcher[Any, Any]]

--- a/src/main/scala/io/getclump/ClumpFetcher.scala
+++ b/src/main/scala/io/getclump/ClumpFetcher.scala
@@ -12,18 +12,18 @@ private[getclump] final class ClumpFetcher[T, U](source: ClumpSource[T, U]) {
       fetches.getOrElseUpdate(input, Promise[Option[U]]).future
     }
 
-  def flush(implicit executionContext: ExecutionContext): Future[Unit] =
+  def flush(implicit ec: ExecutionContext): Future[Unit] =
     synchronized {
       Future.sequence(flushInBatches).map(_ => ())
     }
 
-  private[this] def flushInBatches(implicit executionContext: ExecutionContext) =
+  private[this] def flushInBatches(implicit ec: ExecutionContext) =
     pendingFetches
       .grouped(source.maxBatchSize)
       .toList
       .map(fetchBatch)
 
-  private[this] def fetchBatch(batch: List[T])(implicit executionContext: ExecutionContext) = {
+  private[this] def fetchBatch(batch: List[T])(implicit ec: ExecutionContext) = {
     val results = fetchWithRetries(batch, 0)
     for (input <- batch) {
       val fetch = fetches(input)
@@ -33,7 +33,7 @@ private[getclump] final class ClumpFetcher[T, U](source: ClumpSource[T, U]) {
     results
   }
 
-  private[this] def fetchWithRetries(batch: List[T], retries: Int)(implicit executionContext: ExecutionContext): Future[Map[T, U]] =
+  private[this] def fetchWithRetries(batch: List[T], retries: Int)(implicit ec: ExecutionContext): Future[Map[T, U]] =
     source.fetch(batch).recoverWith {
       case exception: Throwable if (maxRetries(exception) > retries) =>
         fetchWithRetries(batch, retries + 1)

--- a/src/main/scala/io/getclump/ClumpFetcher.scala
+++ b/src/main/scala/io/getclump/ClumpFetcher.scala
@@ -1,6 +1,7 @@
 package io.getclump
 
 import scala.collection.mutable
+import scala.concurrent.ExecutionContext
 
 private[getclump] final class ClumpFetcher[T, U](source: ClumpSource[T, U]) {
 
@@ -11,18 +12,18 @@ private[getclump] final class ClumpFetcher[T, U](source: ClumpSource[T, U]) {
       fetches.getOrElseUpdate(input, Promise[Option[U]]).future
     }
 
-  def flush: Future[Unit] =
+  def flush(implicit executionContext: ExecutionContext): Future[Unit] =
     synchronized {
       Future.sequence(flushInBatches).map(_ => ())
     }
 
-  private[this] def flushInBatches =
+  private[this] def flushInBatches(implicit executionContext: ExecutionContext) =
     pendingFetches
       .grouped(source.maxBatchSize)
       .toList
       .map(fetchBatch)
 
-  private[this] def fetchBatch(batch: List[T]) = {
+  private[this] def fetchBatch(batch: List[T])(implicit executionContext: ExecutionContext) = {
     val results = fetchWithRetries(batch, 0)
     for (input <- batch) {
       val fetch = fetches(input)
@@ -32,7 +33,7 @@ private[getclump] final class ClumpFetcher[T, U](source: ClumpSource[T, U]) {
     results
   }
 
-  private[this] def fetchWithRetries(batch: List[T], retries: Int): Future[Map[T, U]] =
+  private[this] def fetchWithRetries(batch: List[T], retries: Int)(implicit executionContext: ExecutionContext): Future[Map[T, U]] =
     source.fetch(batch).recoverWith {
       case exception: Throwable if (maxRetries(exception) > retries) =>
         fetchWithRetries(batch, retries + 1)

--- a/src/main/scala/io/getclump/Sources.scala
+++ b/src/main/scala/io/getclump/Sources.scala
@@ -11,70 +11,70 @@ protected[getclump] trait Sources extends Tuples {
    * the key used to get that value.
    */
   def source[KS, V, K](fetch: KS => Future[Iterable[V]])(keyExtractor: V => K)
-                      (implicit cbf: CanBuildFrom[Nothing, K, KS], executionContext: ExecutionContext): ClumpSource[K, V] =
+                      (implicit cbf: CanBuildFrom[Nothing, K, KS], ec: ExecutionContext): ClumpSource[K, V] =
     new ClumpSource(extractKeys(adaptInput(fetch), keyExtractor))
 
   /**
    * Similar to [[source]] but also accepts 1 extra param
    */
   def source[A, KS, V, K](fetch: (A, KS) => Future[Iterable[V]])(keyExtractor: V => K)
-                         (implicit cbf: CanBuildFrom[Nothing, K, KS], executionContext: ExecutionContext): ClumpSource[(A, K), V] =
+                         (implicit cbf: CanBuildFrom[Nothing, K, KS], ec: ExecutionContext): ClumpSource[(A, K), V] =
     new ClumpSource(parameterizeFetch(normalize1, denormalize1[A, K], fetch1(fetch), keyExtractor))
 
   /**
    * Similar to [[source]] but also accepts 2 extra params
    */
   def source[A, B, KS, V, K](fetch: (A, B, KS) => Future[Iterable[V]])(keyExtractor: V => K)
-                            (implicit cbf: CanBuildFrom[Nothing, K, KS], executionContext: ExecutionContext): ClumpSource[(A, B, K), V] =
+                            (implicit cbf: CanBuildFrom[Nothing, K, KS], ec: ExecutionContext): ClumpSource[(A, B, K), V] =
     new ClumpSource(parameterizeFetch(normalize2, denormalize2[A, B, K], fetch2(fetch), keyExtractor))
 
   /**
    * Similar to [[source]] but also accepts 3 extra params
    */
   def source[A, B, C, KS, V, K](fetch: (A, B, C, KS) => Future[Iterable[V]])(keyExtractor: V => K)
-                               (implicit cbf: CanBuildFrom[Nothing, K, KS], executionContext: ExecutionContext): ClumpSource[(A, B, C, K), V] =
+                               (implicit cbf: CanBuildFrom[Nothing, K, KS], ec: ExecutionContext): ClumpSource[(A, B, C, K), V] =
     new ClumpSource(parameterizeFetch(normalize3, denormalize3[A, B, C, K], fetch3(fetch), keyExtractor))
 
   /**
    * Similar to [[source]] but also accepts 4 extra params
    */
   def source[A, B, C, D, KS, V, K](fetch: (A, B, C, D, KS) => Future[Iterable[V]])(keyExtractor: V => K)
-                                  (implicit cbf: CanBuildFrom[Nothing, K, KS], executionContext: ExecutionContext): ClumpSource[(A, B, C, D, K), V] =
+                                  (implicit cbf: CanBuildFrom[Nothing, K, KS], ec: ExecutionContext): ClumpSource[(A, B, C, D, K), V] =
     new ClumpSource(parameterizeFetch(normalize4, denormalize4[A, B, C, D, K], fetch4(fetch), keyExtractor))
 
   /**
    * Create a clump source from a function that accepts inputs and returns a future map from input to resulting value.
    */
   def source[KS, K, V](fetch: KS => Future[Map[K, V]])
-                      (implicit cbf: CanBuildFrom[Nothing, K, KS], executionContext: ExecutionContext): ClumpSource[K, V] =
+                      (implicit cbf: CanBuildFrom[Nothing, K, KS], ec: ExecutionContext): ClumpSource[K, V] =
     new ClumpSource(adaptOutput(adaptInput(fetch)))
 
   /**
    * Similar to [[source]] but also accepts 1 extra param
    */
   def source[A, KS, K, V](fetch: (A, KS) => Future[Map[K, V]])
-                         (implicit cbf: CanBuildFrom[Nothing, K, KS], executionContext: ExecutionContext): ClumpSource[(A, K), V] =
+                         (implicit cbf: CanBuildFrom[Nothing, K, KS], ec: ExecutionContext): ClumpSource[(A, K), V] =
     new ClumpSource(parameterizeFetch(normalize1, denormalize1[A, K], fetch1(fetch)))
 
   /**
    * Similar to [[source]] but also accepts 2 extra params
    */
   def source[A, B, KS, K, V](fetch: (A, B, KS) => Future[Map[K, V]])
-                            (implicit cbf: CanBuildFrom[Nothing, K, KS], executionContext: ExecutionContext): ClumpSource[(A, B, K), V] =
+                            (implicit cbf: CanBuildFrom[Nothing, K, KS], ec: ExecutionContext): ClumpSource[(A, B, K), V] =
     new ClumpSource(parameterizeFetch(normalize2, denormalize2[A, B, K], fetch2(fetch)))
 
   /**
    * Similar to [[source]] but also accepts 3 extra params
    */
   def source[A, B, C, KS, K, V](fetch: (A, B, C, KS) => Future[Map[K, V]])
-                               (implicit cbf: CanBuildFrom[Nothing, K, KS], executionContext: ExecutionContext): ClumpSource[(A, B, C, K), V] =
+                               (implicit cbf: CanBuildFrom[Nothing, K, KS], ec: ExecutionContext): ClumpSource[(A, B, C, K), V] =
     new ClumpSource(parameterizeFetch(normalize3, denormalize3[A, B, C, K], fetch3(fetch)))
 
   /**
    * Similar to [[source]] but also accepts 4 extra params
    */
   def source[A, B, C, D, KS, K, V](fetch: (A, B, C, D, KS) => Future[Map[K, V]])
-                                  (implicit cbf: CanBuildFrom[Nothing, K, KS], executionContext: ExecutionContext): ClumpSource[(A, B, C, D, K), V] =
+                                  (implicit cbf: CanBuildFrom[Nothing, K, KS], ec: ExecutionContext): ClumpSource[(A, B, C, D, K), V] =
     new ClumpSource(parameterizeFetch(normalize4, denormalize4[A, B, C, D, K], fetch4(fetch)))
 
   /**
@@ -82,65 +82,65 @@ protected[getclump] trait Sources extends Tuples {
    * Unlike in [[source]], the order of the returned values must be the same as the list of keys that was passed in as
    * the key and value lists will be zipped together to create a map from key to value.
    */
-  def sourceZip[K, V](fetch: List[K] => Future[List[V]])(implicit executionContext: ExecutionContext): ClumpSource[K, V] =
+  def sourceZip[K, V](fetch: List[K] => Future[List[V]])(implicit ec: ExecutionContext): ClumpSource[K, V] =
     new ClumpSource(zipped(fetch))
 
   /**
    * Similar to [[sourceZip]] but also accepts 1 extra param
    */
-  def sourceZip[A, K, V](fetch: (A, List[K]) => Future[List[V]])(implicit executionContext: ExecutionContext): ClumpSource[(A, K), V] =
+  def sourceZip[A, K, V](fetch: (A, List[K]) => Future[List[V]])(implicit ec: ExecutionContext): ClumpSource[(A, K), V] =
     new ClumpSource(parameterizeFetchZip(normalize1, fetch1(fetch)))
 
   /**
    * Similar to [[sourceZip]] but also accepts 2 extra params
    */
-  def sourceZip[A, B, K, V](fetch: (A, B, List[K]) => Future[List[V]])(implicit executionContext: ExecutionContext): ClumpSource[(A, B, K), V] =
+  def sourceZip[A, B, K, V](fetch: (A, B, List[K]) => Future[List[V]])(implicit ec: ExecutionContext): ClumpSource[(A, B, K), V] =
     new ClumpSource(parameterizeFetchZip(normalize2, fetch2(fetch)))
 
   /**
    * Similar to [[sourceZip]] but also accepts 3 extra params
    */
-  def sourceZip[A, B, C, K, V](fetch: (A, B, C, List[K]) => Future[List[V]])(implicit executionContext: ExecutionContext): ClumpSource[(A, B, C, K), V] =
+  def sourceZip[A, B, C, K, V](fetch: (A, B, C, List[K]) => Future[List[V]])(implicit ec: ExecutionContext): ClumpSource[(A, B, C, K), V] =
     new ClumpSource(parameterizeFetchZip(normalize3, fetch3(fetch)))
 
   /**
    * Similar to [[sourceZip]] but also accepts 4 extra params
    */
-  def sourceZip[A, B, C, D, K, V](fetch: (A, B, C, D, List[K]) => Future[List[V]])(implicit executionContext: ExecutionContext): ClumpSource[(A, B, C, D, K), V] =
+  def sourceZip[A, B, C, D, K, V](fetch: (A, B, C, D, List[K]) => Future[List[V]])(implicit ec: ExecutionContext): ClumpSource[(A, B, C, D, K), V] =
     new ClumpSource(parameterizeFetchZip(normalize4, fetch4(fetch)))
 
   /**
    * Create a clump source from a function that accepts a single input and returns a future value.
    * This is for creating a clump source for an endpoint that doesn't support bulk fetches.
    */
-  def sourceSingle[K, V](fetch: K => Future[V])(implicit executionContext: ExecutionContext): ClumpSource[K, V] = source(adapt(fetch))
+  def sourceSingle[K, V](fetch: K => Future[V])(implicit ec: ExecutionContext): ClumpSource[K, V] = source(adapt(fetch))
 
   /**
    * Similar to [[sourceSingle]] but also accepts 1 extra param
    */
-  def sourceSingle[A, K, V](fetch: (A, K) => Future[V])(implicit executionContext: ExecutionContext): ClumpSource[(A, K), V] = source(adapt1(fetch))
+  def sourceSingle[A, K, V](fetch: (A, K) => Future[V])(implicit ec: ExecutionContext): ClumpSource[(A, K), V] = source(adapt1(fetch))
 
   /**
    * Similar to [[sourceSingle]] but also accepts 2 extra params
    */
-  def sourceSingle[A, B, K, V](fetch: (A, B, K) => Future[V])(implicit executionContext: ExecutionContext): ClumpSource[(A, B, K), V] = source(adapt2(fetch))
+  def sourceSingle[A, B, K, V](fetch: (A, B, K) => Future[V])(implicit ec: ExecutionContext): ClumpSource[(A, B, K), V] = source(adapt2(fetch))
 
   /**
    * Similar to [[sourceSingle]] but also accepts 3 extra params
    */
-  def sourceSingle[A, B, C, K, V](fetch: (A, B, C, K) => Future[V])(implicit executionContext: ExecutionContext): ClumpSource[(A, B, C, K), V] = source(adapt3(fetch))
+  def sourceSingle[A, B, C, K, V](fetch: (A, B, C, K) => Future[V])(implicit ec: ExecutionContext): ClumpSource[(A, B, C, K), V] = source(adapt3(fetch))
 
   /**
    * Similar to [[sourceSingle]] but also accepts 4 extra params
    */
-  def sourceSingle[A, B, C, D, K, V](fetch: (A, B, C, D, K) => Future[V])(implicit executionContext: ExecutionContext): ClumpSource[(A, B, C, D, K), V] = source(adapt4(fetch))
+  def sourceSingle[A, B, C, D, K, V](fetch: (A, B, C, D, K) => Future[V])(implicit ec: ExecutionContext): ClumpSource[(A, B, C, D, K), V] = source(adapt4(fetch))
 
   private[this] def parameterizeFetch[I, P, O, T, C](normalize: I => (P, T), denormalize: (P, T) => I, fetch: (P, C) => Future[Iterable[O]], extractKey: O => T)
-                                                    (implicit cbf: CanBuildFrom[Nothing, T, C], executionContext: ExecutionContext): List[I] => Future[Map[I, O]] =
+                                                    (implicit cbf: CanBuildFrom[Nothing, T, C], ec: ExecutionContext): List[I] => Future[Map[I, O]] =
     parameterizeFetch[I, P, O, T, C](normalize, denormalize, fetch = (params: P, coll: C) => fetch(params, coll).map(_.map(v => extractKey(v) -> v).toMap))
 
   private[this] def parameterizeFetch[I, P, O, T, C](normalize: I => (P, T), denormalize: (P, T) => I, fetch: (P, C) => Future[Iterable[(T, O)]])
-                                                    (implicit cbf: CanBuildFrom[Nothing, T, C], executionContext: ExecutionContext): List[I] => Future[Map[I, O]] =
+                                                    (implicit cbf: CanBuildFrom[Nothing, T, C], ec: ExecutionContext): List[I] => Future[Map[I, O]] =
     (inputs: List[I]) => {
       val futures =
         inputs.map(normalize).groupBy { case (params, _) => params }.map {
@@ -152,7 +152,7 @@ protected[getclump] trait Sources extends Tuples {
       Future.sequence(futures).map(_.reduce(_ ++ _).toMap)
     }
 
-  private[this] def parameterizeFetchZip[I, P, O, T](normalize: I => (P, T), fetch: (P, List[T]) => Future[Iterable[O]])(implicit executionContext: ExecutionContext): List[I] => Future[Map[I, O]] =
+  private[this] def parameterizeFetchZip[I, P, O, T](normalize: I => (P, T), fetch: (P, List[T]) => Future[Iterable[O]])(implicit ec: ExecutionContext): List[I] => Future[Map[I, O]] =
     (inputs: List[I]) => {
       val futures =
         inputs.map(normalize).groupBy { case (params, _) => params }.map {
@@ -163,11 +163,11 @@ protected[getclump] trait Sources extends Tuples {
       listOutputs.map(inputs.zip(_).toMap)
     }
 
-  private[this] def zipped[T, U](fetch: List[T] => Future[List[U]])(implicit executionContext: ExecutionContext) = {
+  private[this] def zipped[T, U](fetch: List[T] => Future[List[U]])(implicit ec: ExecutionContext) = {
     (inputs: List[T]) => fetch(inputs).map(inputs.zip(_).toMap)
   }
 
-  private[this] def extractKeys[T, U](fetch: List[T] => Future[Iterable[U]], keyExtractor: U => T)(implicit executionContext: ExecutionContext) =
+  private[this] def extractKeys[T, U](fetch: List[T] => Future[Iterable[U]], keyExtractor: U => T)(implicit ec: ExecutionContext) =
     fetch.andThen(_.map(resultsToKeys(keyExtractor, _)))
 
   private[this] def resultsToKeys[U, T](keyExtractor: (U) => T, results: Iterable[U]) =
@@ -176,7 +176,7 @@ protected[getclump] trait Sources extends Tuples {
   private[this] def adaptInput[T, C, R](fetch: C => Future[R])(implicit cbf: CanBuildFrom[Nothing, T, C]) =
     (c: List[T]) => fetch(cbf.apply().++=(c).result())
 
-  private[this] def adaptOutput[T, U, C](fetch: C => Future[Iterable[(T, U)]])(implicit executionContext: ExecutionContext) =
+  private[this] def adaptOutput[T, U, C](fetch: C => Future[Iterable[(T, U)]])(implicit ec: ExecutionContext) =
     fetch.andThen(_.map(_.toMap))
 
 }

--- a/src/main/scala/io/getclump/Tuples.scala
+++ b/src/main/scala/io/getclump/Tuples.scala
@@ -1,5 +1,7 @@
 package io.getclump
 
+import scala.concurrent.ExecutionContext
+
 
 protected[getclump] trait Tuples {
   protected[getclump] def normalize1[A, B] = (inputs: (A, B)) => inputs match {
@@ -50,18 +52,18 @@ protected[getclump] trait Tuples {
     case ((a, b, c, d), e) => fetch(a, b, c, d, e)
   }
 
-  protected[getclump] def adapt[A, B](fetch: A => Future[B]) = (keys: Iterable[A]) =>
+  protected[getclump] def adapt[A, B](fetch: A => Future[B])(implicit executionContext: ExecutionContext) = (keys: Iterable[A]) =>
     Future.sequence(keys.toSeq.map(key => fetch(key).map(value => key -> value))).map(_.toMap)
 
-  protected[getclump] def adapt1[A, B, C](fetch: (A, B) => Future[C]) = (a: A, keys: Iterable[B]) =>
+  protected[getclump] def adapt1[A, B, C](fetch: (A, B) => Future[C])(implicit executionContext: ExecutionContext) = (a: A, keys: Iterable[B]) =>
     Future.sequence(keys.toSeq.map(key => fetch(a, key).map(value => key -> value))).map(_.toMap)
 
-  protected[getclump] def adapt2[A, B, C, D](fetch: (A, B, C) => Future[D]) = (a: A, b: B, keys: Iterable[C]) =>
+  protected[getclump] def adapt2[A, B, C, D](fetch: (A, B, C) => Future[D])(implicit executionContext: ExecutionContext) = (a: A, b: B, keys: Iterable[C]) =>
     Future.sequence(keys.toSeq.map(key => fetch(a, b, key).map(value => key -> value))).map(_.toMap)
 
-  protected[getclump] def adapt3[A, B, C, D, E](fetch: (A, B, C, D) => Future[E]) = (a: A, b: B, c: C, keys: Iterable[D]) =>
+  protected[getclump] def adapt3[A, B, C, D, E](fetch: (A, B, C, D) => Future[E])(implicit executionContext: ExecutionContext) = (a: A, b: B, c: C, keys: Iterable[D]) =>
     Future.sequence(keys.toSeq.map(key => fetch(a, b, c, key).map(value => key -> value))).map(_.toMap)
 
-  protected[getclump] def adapt4[A, B, C, D, E, F](fetch: (A, B, C, D, E) => Future[F]) = (a: A, b: B, c: C, d: D, keys: Iterable[E]) =>
+  protected[getclump] def adapt4[A, B, C, D, E, F](fetch: (A, B, C, D, E) => Future[F])(implicit executionContext: ExecutionContext) = (a: A, b: B, c: C, d: D, keys: Iterable[E]) =>
     Future.sequence(keys.toSeq.map(key => fetch(a, b, c, d, key).map(value => key -> value))).map(_.toMap)
 }

--- a/src/main/scala/io/getclump/Tuples.scala
+++ b/src/main/scala/io/getclump/Tuples.scala
@@ -52,18 +52,18 @@ protected[getclump] trait Tuples {
     case ((a, b, c, d), e) => fetch(a, b, c, d, e)
   }
 
-  protected[getclump] def adapt[A, B](fetch: A => Future[B])(implicit executionContext: ExecutionContext) = (keys: Iterable[A]) =>
+  protected[getclump] def adapt[A, B](fetch: A => Future[B])(implicit ec: ExecutionContext) = (keys: Iterable[A]) =>
     Future.sequence(keys.toSeq.map(key => fetch(key).map(value => key -> value))).map(_.toMap)
 
-  protected[getclump] def adapt1[A, B, C](fetch: (A, B) => Future[C])(implicit executionContext: ExecutionContext) = (a: A, keys: Iterable[B]) =>
+  protected[getclump] def adapt1[A, B, C](fetch: (A, B) => Future[C])(implicit ec: ExecutionContext) = (a: A, keys: Iterable[B]) =>
     Future.sequence(keys.toSeq.map(key => fetch(a, key).map(value => key -> value))).map(_.toMap)
 
-  protected[getclump] def adapt2[A, B, C, D](fetch: (A, B, C) => Future[D])(implicit executionContext: ExecutionContext) = (a: A, b: B, keys: Iterable[C]) =>
+  protected[getclump] def adapt2[A, B, C, D](fetch: (A, B, C) => Future[D])(implicit ec: ExecutionContext) = (a: A, b: B, keys: Iterable[C]) =>
     Future.sequence(keys.toSeq.map(key => fetch(a, b, key).map(value => key -> value))).map(_.toMap)
 
-  protected[getclump] def adapt3[A, B, C, D, E](fetch: (A, B, C, D) => Future[E])(implicit executionContext: ExecutionContext) = (a: A, b: B, c: C, keys: Iterable[D]) =>
+  protected[getclump] def adapt3[A, B, C, D, E](fetch: (A, B, C, D) => Future[E])(implicit ec: ExecutionContext) = (a: A, b: B, c: C, keys: Iterable[D]) =>
     Future.sequence(keys.toSeq.map(key => fetch(a, b, c, key).map(value => key -> value))).map(_.toMap)
 
-  protected[getclump] def adapt4[A, B, C, D, E, F](fetch: (A, B, C, D, E) => Future[F])(implicit executionContext: ExecutionContext) = (a: A, b: B, c: C, d: D, keys: Iterable[E]) =>
+  protected[getclump] def adapt4[A, B, C, D, E, F](fetch: (A, B, C, D, E) => Future[F])(implicit ec: ExecutionContext) = (a: A, b: B, c: C, d: D, keys: Iterable[E]) =>
     Future.sequence(keys.toSeq.map(key => fetch(a, b, c, d, key).map(value => key -> value))).map(_.toMap)
 }

--- a/src/main/scala/io/getclump/Utils.scala
+++ b/src/main/scala/io/getclump/Utils.scala
@@ -1,0 +1,13 @@
+package io.getclump
+
+private[getclump] case class RunOnce[T, U](f: T => Clump[U]) extends (T => Clump[U]) {
+  var cache: Option[Clump[U]] = None
+  override def apply(t: T) = synchronized {
+    cache.getOrElse {
+      val ans = f(t)
+      cache = Some(ans)
+      ans
+    }
+  }
+}
+

--- a/src/main/scala/io/getclump/package-twitter.scala.tmpl
+++ b/src/main/scala/io/getclump/package-twitter.scala.tmpl
@@ -2,6 +2,9 @@ package io
 
 package object getclump {
 
+  // Execution contexts are not used by twitter-util so this allows you not to have to specify it
+  private[getclump] implicit val ec = scala.concurrent.ExecutionContext.global
+
   private[getclump]type Promise[T] = com.twitter.util.Promise[T]
   private[getclump] val Promise = com.twitter.util.Promise
 

--- a/src/main/scala/io/getclump/package-twitter.scala.tmpl
+++ b/src/main/scala/io/getclump/package-twitter.scala.tmpl
@@ -24,7 +24,7 @@ package object getclump {
   implicit class FutureCompanionBridge(val companion: Future.type) extends AnyVal {
     def successful[T](value: T) = Future.value(value)
     def failed[T](exception: Throwable) = Future.exception[T](exception)
-    def sequence[T](futures: Seq[Future[T]]) = Future.collect(futures)
+    def sequence[T](futures: Iterable[Future[T]]) = Future.collect(futures.toSeq).map(_.toList)
   }
 
   private[getclump] def awaitResult[T](future: Future[T]) =

--- a/src/main/scala/io/getclump/package.scala
+++ b/src/main/scala/io/getclump/package.scala
@@ -2,8 +2,6 @@ package io
 
 package object getclump {
 
-//  private[getclump] implicit val executionContext = scala.concurrent.ExecutionContext.global
-
   private[getclump]type Promise[T] = scala.concurrent.Promise[T]
   private[getclump] val Promise = scala.concurrent.Promise
 

--- a/src/main/scala/io/getclump/package.scala
+++ b/src/main/scala/io/getclump/package.scala
@@ -2,7 +2,7 @@ package io
 
 package object getclump {
 
-  private[getclump] implicit val executionContext = scala.concurrent.ExecutionContext.global
+//  private[getclump] implicit val executionContext = scala.concurrent.ExecutionContext.global
 
   private[getclump]type Promise[T] = scala.concurrent.Promise[T]
   private[getclump] val Promise = scala.concurrent.Promise

--- a/src/test/scala/io/getclump/ClumpExecutionSpec.scala
+++ b/src/test/scala/io/getclump/ClumpExecutionSpec.scala
@@ -14,6 +14,7 @@ class ClumpExecutionSpec extends Spec {
     val source3Fetches = ListBuffer[Set[Int]]()
 
     protected def fetchFunction(fetches: ListBuffer[Set[Int]], inputs: Set[Int]) = {
+      println(inputs)
       fetches += inputs
       Future.successful(inputs.map(i => i -> i * 10).toMap)
     }
@@ -26,6 +27,7 @@ class ClumpExecutionSpec extends Spec {
   "batches requests" >> {
 
     "for multiple clumps created from traversed inputs" in new Context {
+      skipped
       val clump =
         Clump.traverse(List(1, 2, 3, 4)) {
           i =>
@@ -41,6 +43,7 @@ class ClumpExecutionSpec extends Spec {
     }
 
     "for multiple clumps collected into only one clump" in new Context {
+      skipped
       val clump = Clump.collect(source1.get(1), source1.get(2), source2.get(3), source2.get(4))
 
       clumpResult(clump) mustEqual Some(List(10, 20, 30, 40))
@@ -49,6 +52,7 @@ class ClumpExecutionSpec extends Spec {
     }
 
     "for clumps created inside nested flatmaps" in new Context {
+      skipped
       val clump1 = Clump.value(1).flatMap(source1.get(_)).flatMap(source2.get(_))
       val clump2 = Clump.value(2).flatMap(source1.get(_)).flatMap(source2.get(_))
 
@@ -60,6 +64,7 @@ class ClumpExecutionSpec extends Spec {
     "for clumps composed using for comprehension" >> {
 
       "one level" in new Context {
+        skipped
         val clump =
           for {
             int <- Clump.collect(source1.get(1), source1.get(2), source2.get(3), source2.get(4))
@@ -83,6 +88,7 @@ class ClumpExecutionSpec extends Spec {
       }
 
       "with a filter condition" in new Context {
+        skipped
         val clump =
           for {
             ints1 <- Clump.collect(source1.get(1), source1.get(2))
@@ -95,6 +101,7 @@ class ClumpExecutionSpec extends Spec {
       }
 
       "using a join" in new Context {
+        skipped
         val clump =
           for {
             ints1 <- Clump.collect(source1.get(1), source1.get(2))
@@ -107,6 +114,7 @@ class ClumpExecutionSpec extends Spec {
       }
 
       "using a future clump as base" in new Context {
+        skipped
         val clump =
           for {
             int <- Clump.future(Future.successful(Some(1)))
@@ -120,6 +128,7 @@ class ClumpExecutionSpec extends Spec {
       }
 
       "complex scenario" in new Context {
+        skipped
         val clump =
           for {
             const1 <- Clump.value(1)
@@ -138,6 +147,7 @@ class ClumpExecutionSpec extends Spec {
   }
 
   "executes 2 joined clumps in parallel" in new Context {
+    skipped
     val promises = List(Promise[Map[Int, Int]](), Promise[Map[Int, Int]]())
 
     val promisesIterator = promises.iterator
@@ -153,6 +163,7 @@ class ClumpExecutionSpec extends Spec {
   }
 
   "executes 2 joined clumps in parallel at different levels of composition" in new Context {
+    skipped
     val promises = List(Promise[Map[Int, Int]](), Promise[Map[Int, Int]]())
 
     val promisesIterator = promises.iterator
@@ -168,6 +179,7 @@ class ClumpExecutionSpec extends Spec {
   }
 
   "executes 3 joined clumps in parallel" in new Context {
+    skipped
     val promises = List(Promise[Map[Int, Int]](), Promise[Map[Int, Int]](), Promise[Map[Int, Int]]())
 
     val promisesIterator = promises.iterator
@@ -183,6 +195,7 @@ class ClumpExecutionSpec extends Spec {
   }
 
   "short-circuits the computation in case of a failure" in new Context {
+    skipped
     val clump = Clump.exception[Int](new IllegalStateException).map(_ => throw new NullPointerException)
     clumpResult(clump) must throwA[IllegalStateException]
   }

--- a/src/test/scala/io/getclump/ClumpExecutionSpec.scala
+++ b/src/test/scala/io/getclump/ClumpExecutionSpec.scala
@@ -78,11 +78,11 @@ class ClumpExecutionSpec extends Spec {
       "two levels" in new Context {
         val clump =
           for {
-            ints1 <- Clump.collect(source1.get(1), source1.get(2))
-            ints2 <- Clump.collect(source2.get(3), source2.get(4))
+            ints1 <- source1.get(1)
+            ints2 <- source2.get(3)
           } yield (ints1, ints2)
 
-        clumpResult(clump) mustEqual Some(List(10, 20), List(30, 40))
+        clump.get must beEqualTo(Some(List(10, 20), List(30, 40))).await
         source1Fetches mustEqual List(Set(1, 2))
         source2Fetches mustEqual List(Set(3, 4))
       }

--- a/src/test/scala/io/getclump/ClumpExecutionSpec.scala
+++ b/src/test/scala/io/getclump/ClumpExecutionSpec.scala
@@ -14,7 +14,6 @@ class ClumpExecutionSpec extends Spec {
     val source3Fetches = ListBuffer[Set[Int]]()
 
     protected def fetchFunction(fetches: ListBuffer[Set[Int]], inputs: Set[Int]) = {
-      println(inputs)
       fetches += inputs
       Future.successful(inputs.map(i => i -> i * 10).toMap)
     }
@@ -27,7 +26,6 @@ class ClumpExecutionSpec extends Spec {
   "batches requests" >> {
 
     "for multiple clumps created from traversed inputs" in new Context {
-      skipped
       val clump =
         Clump.traverse(List(1, 2, 3, 4)) {
           i =>
@@ -43,7 +41,6 @@ class ClumpExecutionSpec extends Spec {
     }
 
     "for multiple clumps collected into only one clump" in new Context {
-      skipped
       val clump = Clump.collect(source1.get(1), source1.get(2), source2.get(3), source2.get(4))
 
       clumpResult(clump) mustEqual Some(List(10, 20, 30, 40))
@@ -52,7 +49,6 @@ class ClumpExecutionSpec extends Spec {
     }
 
     "for clumps created inside nested flatmaps" in new Context {
-      skipped
       val clump1 = Clump.value(1).flatMap(source1.get(_)).flatMap(source2.get(_))
       val clump2 = Clump.value(2).flatMap(source1.get(_)).flatMap(source2.get(_))
 
@@ -64,7 +60,6 @@ class ClumpExecutionSpec extends Spec {
     "for clumps composed using for comprehension" >> {
 
       "one level" in new Context {
-        skipped
         val clump =
           for {
             int <- Clump.collect(source1.get(1), source1.get(2), source2.get(3), source2.get(4))
@@ -78,17 +73,16 @@ class ClumpExecutionSpec extends Spec {
       "two levels" in new Context {
         val clump =
           for {
-            ints1 <- source1.get(1)
-            ints2 <- source2.get(3)
+            ints1 <- Clump.collect(source1.get(1), source1.get(2))
+            ints2 <- Clump.collect(source2.get(3), source2.get(4))
           } yield (ints1, ints2)
 
-        clump.get must beEqualTo(Some(List(10, 20), List(30, 40))).await
+        clumpResult(clump) mustEqual Some(List(10, 20), List(30, 40))
         source1Fetches mustEqual List(Set(1, 2))
         source2Fetches mustEqual List(Set(3, 4))
       }
 
       "with a filter condition" in new Context {
-        skipped
         val clump =
           for {
             ints1 <- Clump.collect(source1.get(1), source1.get(2))
@@ -101,7 +95,6 @@ class ClumpExecutionSpec extends Spec {
       }
 
       "using a join" in new Context {
-        skipped
         val clump =
           for {
             ints1 <- Clump.collect(source1.get(1), source1.get(2))
@@ -114,7 +107,6 @@ class ClumpExecutionSpec extends Spec {
       }
 
       "using a future clump as base" in new Context {
-        skipped
         val clump =
           for {
             int <- Clump.future(Future.successful(Some(1)))
@@ -128,7 +120,6 @@ class ClumpExecutionSpec extends Spec {
       }
 
       "complex scenario" in new Context {
-        skipped
         val clump =
           for {
             const1 <- Clump.value(1)
@@ -147,7 +138,6 @@ class ClumpExecutionSpec extends Spec {
   }
 
   "executes 2 joined clumps in parallel" in new Context {
-    skipped
     val promises = List(Promise[Map[Int, Int]](), Promise[Map[Int, Int]]())
 
     val promisesIterator = promises.iterator
@@ -163,7 +153,6 @@ class ClumpExecutionSpec extends Spec {
   }
 
   "executes 2 joined clumps in parallel at different levels of composition" in new Context {
-    skipped
     val promises = List(Promise[Map[Int, Int]](), Promise[Map[Int, Int]]())
 
     val promisesIterator = promises.iterator
@@ -179,7 +168,6 @@ class ClumpExecutionSpec extends Spec {
   }
 
   "executes 3 joined clumps in parallel" in new Context {
-    skipped
     val promises = List(Promise[Map[Int, Int]](), Promise[Map[Int, Int]](), Promise[Map[Int, Int]]())
 
     val promisesIterator = promises.iterator
@@ -195,7 +183,6 @@ class ClumpExecutionSpec extends Spec {
   }
 
   "short-circuits the computation in case of a failure" in new Context {
-    skipped
     val clump = Clump.exception[Int](new IllegalStateException).map(_ => throw new NullPointerException)
     clumpResult(clump) must throwA[IllegalStateException]
   }

--- a/src/test/scala/io/getclump/ClumpExecutionSpec.scala
+++ b/src/test/scala/io/getclump/ClumpExecutionSpec.scala
@@ -40,6 +40,23 @@ class ClumpExecutionSpec extends Spec {
       source2Fetches mustEqual List(Set(3, 4))
     }
 
+    "for multiple clumps collected into only one clump" in new Context {
+      val clump = Clump.collect(source1.get(1), source1.get(2), source2.get(3), source2.get(4))
+
+      clumpResult(clump) mustEqual Some(List(10, 20, 30, 40))
+      source1Fetches mustEqual List(Set(1, 2))
+      source2Fetches mustEqual List(Set(3, 4))
+    }
+
+    "for clumps created inside nested flatmaps" in new Context {
+      val clump1 = Clump.value(1).flatMap(source1.get(_)).flatMap(source2.get(_))
+      val clump2 = Clump.value(2).flatMap(source1.get(_)).flatMap(source2.get(_))
+
+      clumpResult(Clump.collect(clump1, clump2)) mustEqual Some(List(100, 200))
+      source1Fetches mustEqual List(Set(1, 2))
+      source2Fetches mustEqual List(Set(20, 10))
+    }
+
     "for clumps composed using for comprehension" >> {
 
       "one level" in new Context {

--- a/src/test/scala/io/getclump/ClumpExecutionSpec.scala
+++ b/src/test/scala/io/getclump/ClumpExecutionSpec.scala
@@ -149,7 +149,7 @@ class ClumpExecutionSpec extends Spec {
 
     val future: Future[Option[(Int, Int)]] = clump.get
 
-    promises.size mustEqual 2
+    promisesIterator.hasNext must beFalse
   }
 
   "executes 2 joined clumps in parallel at different levels of composition" in new Context {
@@ -164,7 +164,7 @@ class ClumpExecutionSpec extends Spec {
 
     val future: Future[Option[(Int, Int)]] = clump.get
 
-    promises.size mustEqual 2
+    promisesIterator.hasNext must beFalse
   }
 
   "executes 3 joined clumps in parallel" in new Context {
@@ -179,7 +179,7 @@ class ClumpExecutionSpec extends Spec {
 
     val future: Future[Option[(Int, Int, Int)]] = clump.get
 
-    promises.size mustEqual 3
+    promisesIterator.hasNext must beFalse
   }
 
   "short-circuits the computation in case of a failure" in new Context {


### PR DESCRIPTION
This branch is based off my other pull request with the optimized fetching algorithm https://github.com/getclump/clump/pull/99

There's essentially one execution context that gets used for the various transformations to the source function, and another that gets used throughout the entire fetch process.