### PR TITLE
Demonstration of val vs. def problem

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -62,7 +62,7 @@ object Build extends Build {
     .settings(name := "clump-scala")
     .settings(commonSettings: _*)
     .settings(target <<= target(_ / "clump-scala"))
-    .aggregate(clumpTwitter)
+//    .aggregate(clumpTwitter)
 
   lazy val clumpTwitter = Project(id = "clump-twitter", base = file("."))
     .settings(name := "clump-twitter")

--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -239,7 +239,7 @@ private[getclump] class ClumpMap[T, U](clump: Clump[T], f: T => U) extends Clump
 
 private[getclump] class ClumpFlatMap[T, U](clump: Clump[T], f: T => Clump[U]) extends Clump[U] {
   val upstream = List(clump)
-  val partial =
+  def partial =
     clump.result.map(_.map(f))
   val downstream =
     partial.map(_.toList)
@@ -259,7 +259,7 @@ private[getclump] class ClumpHandle[T](clump: Clump[T], f: PartialFunction[Throw
 
 private[getclump] class ClumpRescue[T](clump: Clump[T], rescue: PartialFunction[Throwable, Clump[T]]) extends Clump[T] {
   val upstream = List(clump)
-  val partial =
+  def partial =
     clump.result.map(Clump.value).recover {
       case exception if (rescue.isDefinedAt(exception)) => rescue(exception)
       case exception                                    => Clump.exception(exception)
@@ -279,7 +279,7 @@ private[getclump] class ClumpFilter[T](clump: Clump[T], f: T => Boolean) extends
 
 private[getclump] class ClumpOrElse[T](clump: Clump[T], default: => Clump[T]) extends Clump[T] {
   val upstream = List(clump)
-  val partial =
+  def partial =
     clump.result.map {
       case Some(value) => Clump.value(value)
       case None        => default

--- a/src/test/scala/io/getclump/ProblemSpec.scala
+++ b/src/test/scala/io/getclump/ProblemSpec.scala
@@ -1,0 +1,39 @@
+package io.getclump
+
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ProblemSpec extends Spec {
+
+  val source = Clump.sourceSingle { (x: Int) => Future.successful(x) }
+
+  "doesn't work with flatMap" >> {
+    val clump = for {
+      one <- Clump.value(1)
+      two <- source.get(2) // ClumpFetch needs to be inside ClumpFlatMap
+    } yield (one, two)
+
+    clump.get must beEqualTo(Some((1, 2))).await // timeout!
+  }
+
+  "doesn't work with rescue" >> {
+    val good = Clump.failed(new Exception()).rescue {
+      case _ => Clump.value(1)
+    }
+
+    good.get must beEqualTo(Some(1)).await // passes
+
+    val bad = Clump.failed(new Exception()).rescue {
+      case _ => source.get(2) // again, ClumpFetch needs to be inside ClumpRescue
+    }
+
+    bad.get must beEqualTo(Some(2)).await // timeout!
+  }
+
+  "doesn't work with orElse" >> {
+    val clump = Clump.empty.orElse(source.get(1)) // ClumpFetch inside ClumpOrElse
+
+    clump.get must beEqualTo(Some(1)).await // timeout!
+  }
+}


### PR DESCRIPTION
**NOTE: Don't actually merge this, it's just a demo**

Because the `Clump[U]` result is needed in both the result and downstream in a flatMap, we call the function `f: T => Clump[U]` function in two places. This is fine if the `val partial` is used, but leads to an unexpected deadlock if you simply change the `val` to a `def`. This is because now `f` will be called twice. If `f` creates a `ClumpFetch`, then only one of these fetches will get attached to a fetcher, the other will be left hanging forever.

The same problem is true for rescue and orElse since they both create Clumps as well.