### PR TITLE
Fix issue with CanBuildFrom and collections with metadata

### DIFF
--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -186,8 +186,8 @@ object Clump extends Joins with Sources {
    *   Clump.collect(list.map(f))
    * }}}
    */
-  def traverse[T, U, C[_] <: Iterable[_]](inputs: C[T])(f: T => Clump[U])(implicit cbf: CanBuildFrom[Nothing, U, C[U]]): Clump[C[U]] =
-    collect(inputs.toList.asInstanceOf[List[T]].map(f)).map(cbf.apply().++=(_).result())
+  def traverse[T, U, C[_] <: Iterable[_]](inputs: C[T])(f: T => Clump[U])(implicit cbf: CanBuildFrom[C[T], U, C[U]]): Clump[C[U]] =
+    collect(inputs.toList.asInstanceOf[List[T]].map(f)).map(cbf.apply(inputs).++=(_).result())
 
   /**
    * Transform a collection of clump instances into a single clump
@@ -236,7 +236,7 @@ private[getclump] class ClumpCollect[T, C[_] <: Iterable[_]](clumps: C[Clump[T]]
     Future
       .sequence(upstream.map(_.result))
       .map(_.flatten)
-      .map(cbf.apply().++=(_).result())
+      .map(cbf.apply(clumps).++=(_).result())
       .map(Some(_))
 }
 


### PR DESCRIPTION
Confession to start: I don't have a clear 100% understanding of CanBuildFrom. We experienced an issue in our codebase where we have a very specialized collection type that contains some metadata associated with it. This metadata was being lost by Clump. The solution was just to add a seed to the apply() method of cbf which seems to copy over everything but the elements from the original collection.