### PR TITLE
Simplify API to no longer expose internal Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,16 +305,10 @@ val usersSource =
 
 It is possible to create Clump instances based on values.
 
-From a non-optional value:
+From a value:
 
 ```scala
 val clump: Clump[Int] = Clump.value(111)
-```
-
-From an optional value:
-
-```scala
-val clump: Clump[Int] = Clump.value(Option(111))
 ```
 
 From a future:
@@ -323,8 +317,6 @@ From a future:
 // This method is useful as a bridge between Clump and non-batched services.
 val clump: Clump[Int] = Clump.future(counterService.currentValueFor(111))
 ```
-
-The `future` method is overloaded to be able to receive both `Future[T]` and `Future[Option[T]]`.
 
 It is possible to create a failed Clump instance:
 

--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -2,8 +2,6 @@ package io.getclump
 
 import scala.collection.generic.CanBuildFrom
 import scala.concurrent.ExecutionContext
-
-import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
 sealed trait Clump[+T] {
@@ -66,7 +64,7 @@ sealed trait Clump[+T] {
   /**
    * If this clump does not return a value then use the default instead
    */
-  def orElse[B >: T: ClassTag](default: => B): Clump[B] = new ClumpOrElse(this, Clump.value(default))
+  def orDefault[B >: T](default: => B): Clump[B] = new ClumpOrElse(this, Clump.value(default))
 
   /**
    * If this clump does not return a value then use the value from a default clump instead

--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -26,12 +26,12 @@ sealed trait Clump[+T] {
   /**
    * Define a fallback value to use in the case of specified exceptions
    */
-  def handle[B >: T](f: PartialFunction[Throwable, Option[B]]): Clump[B] = new ClumpHandle(this, f)
+  def handle[B >: T](f: PartialFunction[Throwable, B]): Clump[B] = new ClumpHandle(this, f)
 
   /**
    * Alias for [[handle]]
    */
-  def recover[B >: T](f: PartialFunction[Throwable, Option[B]]): Clump[B] = handle(f)
+  def recover[B >: T](f: PartialFunction[Throwable, B]): Clump[B] = handle(f)
 
   /**
    * Define a fallback clump to use in the case of specified exceptions
@@ -46,7 +46,7 @@ sealed trait Clump[+T] {
   /**
    * On any exception, fallback to a default value
    */
-  def fallback[B >: T](default: => Option[B]): Clump[B] = handle(PartialFunction(_ => default))
+  def fallback[B >: T](default: => B): Clump[B] = handle(PartialFunction(_ => default))
 
   /**
    * On any exception, fallback to a default clump
@@ -116,7 +116,7 @@ object Clump extends Joins with Sources {
   /**
    * Create an empty clump
    */
-  def empty[T]: Clump[T] = value(scala.None)
+  def empty[T]: Clump[T] = new ClumpEmpty()
 
   /**
    * Alias for [[value]] except that it propagates exceptions inside a clump instance
@@ -126,12 +126,7 @@ object Clump extends Joins with Sources {
   /**
    * The unit method: create a clump whose value has already been resolved to the input
    */
-  def value[T](value: T): Clump[T] = future(Future.successful(Option(value)))
-
-  /**
-   * The unit method: create a clump whose value has already been resolved to the input if it is defined
-   */
-  def value[T](value: Option[T]): Clump[T] = future(Future.successful(value))
+  def value[T](value: T): Clump[T] = future(Future.successful(value))
 
   /**
    * Alias for [[value]]
@@ -151,12 +146,7 @@ object Clump extends Joins with Sources {
   /**
    * Create a clump whose value will be the result of the inputted future
    */
-  def future[T: ClassTag](future: Future[T])(implicit ec: ExecutionContext): Clump[T] = new ClumpFuture(future.map(Option(_)))
-
-  /**
-   * Create a clump whose value will be the result of the inputted future if it is defined
-   */
-  def future[T](future: Future[Option[T]]): Clump[T] = new ClumpFuture(future)
+  def future[T](future: Future[T]): Clump[T] = new ClumpFuture(future)
 
   /**
    * Transform a number of values into a single clump by first applying a function.
@@ -203,11 +193,15 @@ object Clump extends Joins with Sources {
 
 }
 
-private[getclump] class ClumpFuture[T](future: Future[Option[T]]) extends Clump[T] {
+private[getclump] class ClumpEmpty extends Clump[Nothing] {
+  override protected[getclump] def result(implicit ec: ExecutionContext) = Future.successful(None)
+}
+
+private[getclump] class ClumpFuture[T](future: Future[T]) extends Clump[T] {
   override protected[getclump] def downstream(implicit ec: ExecutionContext) = future.map(_ => None).recover {
     case _ => None
   }
-  override protected[getclump] def result(implicit ec: ExecutionContext) = future
+  override protected[getclump] def result(implicit ec: ExecutionContext) = future.map(Some(_))
 }
 
 private[getclump] class ClumpFetch[T, U](input: T, val source: ClumpSource[T, U]) extends Clump[U] {
@@ -261,16 +255,16 @@ private[getclump] class ClumpFlatMap[T, U](clump: Clump[T], f: T => Clump[U]) ex
     }
 }
 
-private[getclump] class ClumpHandle[T](clump: Clump[T], f: PartialFunction[Throwable, Option[T]]) extends Clump[T] {
+private[getclump] class ClumpHandle[T](clump: Clump[T], f: PartialFunction[Throwable, T]) extends Clump[T] {
   override protected[getclump] val upstream = List(clump)
   override protected[getclump] def result(implicit ec: ExecutionContext) =
-    clump.result.recover(f)
+    clump.result.recover(f.andThen(Some(_)))
 }
 
 private[getclump] class ClumpRescue[T](clump: Clump[T], rescue: PartialFunction[Throwable, Clump[T]]) extends Clump[T] {
   private[this] val promise = Promise[Clump[T]]
   private[this] def partial(implicit ec: ExecutionContext) =
-    clump.result.map(Clump.value).recover {
+    clump.result.map(_.map(Clump.value).getOrElse(Clump.empty)).recover {
       case exception if rescue.isDefinedAt(exception) => rescue(exception)
       case exception                                  => Clump.exception(exception)
     }

--- a/src/test/scala/io/getclump/ClumpApiSpec.scala
+++ b/src/test/scala/io/getclump/ClumpApiSpec.scala
@@ -319,12 +319,12 @@ class ClumpApiSpec extends Spec {
       (clump: Clump[List[A]]) must beAnInstanceOf[Clump[List[A]]]
     }
 
-    "allows to defined a fallback value (clump.orElse)" >> {
+    "allows to defined a fallback value (clump.orDefault)" >> {
       "undefined" in {
-        clumpResult(Clump.empty.orElse(1)) ==== Some(1)
+        clumpResult(Clump.empty.orDefault(1)) ==== Some(1)
       }
       "defined" in {
-        clumpResult(Clump.value(1).orElse(2)) ==== Some(1)
+        clumpResult(Clump.value(1).orDefault(2)) ==== Some(1)
       }
     }
 

--- a/src/test/scala/io/getclump/ClumpApiSpec.scala
+++ b/src/test/scala/io/getclump/ClumpApiSpec.scala
@@ -13,17 +13,7 @@ class ClumpApiSpec extends Spec {
       "from a future (Clump.future)" >> {
 
         "success" >> {
-          "optional" >> {
-            "defined" in {
-              clumpResult(Clump.future(Future.successful(Some(1)))) mustEqual Some(1)
-            }
-            "undefined" in {
-              clumpResult(Clump.future(Future.successful(None))) mustEqual None
-            }
-          }
-          "non-optional" in {
-            clumpResult(Clump.future(Future.successful(1))) mustEqual Some(1)
-          }
+          clumpResult(Clump.future(Future.successful(1))) mustEqual Some(1)
         }
 
         "failure" in {
@@ -48,17 +38,6 @@ class ClumpApiSpec extends Spec {
 
       "from a value (Clump.successful)" in {
         clumpResult(Clump.successful(1)) mustEqual Some(1)
-      }
-
-      "from an option (Clump.value)" >> {
-
-        "defined" in {
-          clumpResult(Clump.value(Option(1))) mustEqual Option(1)
-        }
-
-        "empty" in {
-          clumpResult(Clump.value(None)) mustEqual None
-        }
       }
 
       "failed (Clump.exception)" in {
@@ -190,7 +169,7 @@ class ClumpApiSpec extends Spec {
           clumpResult(Clump.value(1).flatMap(i => Clump.value(i + 1))) mustEqual Some(2)
         }
         "initial clump is undefined" in {
-          clumpResult(Clump.value(None).flatMap(i => Clump.value(2))) mustEqual None
+          clumpResult(Clump.empty[Int].flatMap(i => Clump.value(2))) mustEqual None
         }
       }
     }
@@ -200,7 +179,7 @@ class ClumpApiSpec extends Spec {
         clumpResult(Clump.value(1).join(Clump.value(2))) mustEqual Some(1, 2)
       }
       "one of them is undefined" in {
-        clumpResult(Clump.value(1).join(Clump.value(None))) mustEqual None
+        clumpResult(Clump.empty[Int].join(Clump.value(None))) mustEqual None
       }
     }
 
@@ -210,21 +189,21 @@ class ClumpApiSpec extends Spec {
         "exception happens" in {
           val clump =
             Clump.exception(new IllegalStateException).handle {
-              case e: IllegalStateException => Some(2)
+              case e: IllegalStateException => 2
             }
           clumpResult(clump) mustEqual Some(2)
         }
         "exception doesn't happen" in {
           val clump =
             Clump.value(1).handle {
-              case e: IllegalStateException => None
+              case e: IllegalStateException => 2
             }
           clumpResult(clump) mustEqual Some(1)
         }
         "exception isn't caught" in {
           val clump =
             Clump.exception(new NullPointerException).handle {
-              case e: IllegalStateException => Some(1)
+              case e: IllegalStateException => 1
             }
           clumpResult(clump) must throwA[NullPointerException]
         }
@@ -234,21 +213,21 @@ class ClumpApiSpec extends Spec {
         "exception happens" in {
           val clump =
             Clump.exception(new IllegalStateException).recover {
-              case e: IllegalStateException => Some(2)
+              case e: IllegalStateException => 2
             }
           clumpResult(clump) mustEqual Some(2)
         }
         "exception doesn't happen" in {
           val clump =
             Clump.value(1).recover {
-              case e: IllegalStateException => None
+              case e: IllegalStateException => 2
             }
           clumpResult(clump) mustEqual Some(1)
         }
         "exception isn't caught" in {
           val clump =
             Clump.exception(new NullPointerException).recover {
-              case e: IllegalStateException => Some(1)
+              case e: IllegalStateException => 1
             }
           clumpResult(clump) must throwA[NullPointerException]
         }
@@ -265,7 +244,7 @@ class ClumpApiSpec extends Spec {
         "exception doesn't happen" in {
           val clump =
             Clump.value(1).rescue {
-              case e: IllegalStateException => Clump.value(None)
+              case e: IllegalStateException => Clump.empty
             }
           clumpResult(clump) mustEqual Some(1)
         }
@@ -289,7 +268,7 @@ class ClumpApiSpec extends Spec {
         "exception doesn't happen" in {
           val clump =
             Clump.value(1).recoverWith {
-              case e: IllegalStateException => Clump.value(None)
+              case e: IllegalStateException => Clump.empty
             }
           clumpResult(clump) mustEqual Some(1)
         }
@@ -304,12 +283,12 @@ class ClumpApiSpec extends Spec {
 
       "using a function that recovers using a new value (clump.fallback) on any exception" >> {
         "exception happens" in {
-          val clump = Clump.exception(new IllegalStateException).fallback(Some(1))
+          val clump = Clump.exception(new IllegalStateException).fallback(1)
           clumpResult(clump) mustEqual Some(1)
         }
 
         "exception doesn't happen" in {
-          val clump = Clump.value(1).fallback(Some(2))
+          val clump = Clump.value(1).fallback(2)
           clumpResult(clump) mustEqual Some(1)
         }
       }
@@ -345,7 +324,7 @@ class ClumpApiSpec extends Spec {
         clumpResult(Clump.empty.orElse(1)) ==== Some(1)
       }
       "defined" in {
-        clumpResult(Clump.value(Some(1)).orElse(2)) ==== Some(1)
+        clumpResult(Clump.value(1).orElse(2)) ==== Some(1)
       }
     }
 
@@ -354,7 +333,7 @@ class ClumpApiSpec extends Spec {
         clumpResult(Clump.empty.orElse(Clump.value(1))) ==== Some(1)
       }
       "defined" in {
-        clumpResult(Clump.value(Some(1)).orElse(Clump.value(2))) ==== Some(1)
+        clumpResult(Clump.value(1).orElse(Clump.value(2))) ==== Some(1)
       }
     }
 
@@ -369,24 +348,24 @@ class ClumpApiSpec extends Spec {
         awaitResult(Clump.value(Seq(1, 2)).list) ==== Seq(1, 2)
       }
       "empty" in {
-        awaitResult(Clump.value[List[Int]](None).list) ==== List()
+        awaitResult(Clump.empty[List[Int]].list) ==== List()
       }
       // Clump.value(1).flatten //doesn't compile
     }
 
     "can provide a result falling back to a default (clump.getOrElse)" >> {
       "initial clump is undefined" in {
-        awaitResult(Clump.value(None).getOrElse(1)) ==== 1
+        awaitResult(Clump.empty.getOrElse(1)) ==== 1
       }
 
       "initial clump is defined" in {
-        awaitResult(Clump.value(Some(2)).getOrElse(1)) ==== 2
+        awaitResult(Clump.value(2).getOrElse(1)) ==== 2
       }
     }
 
     "has a utility method (clump.apply) for unwrapping optional result" in {
       awaitResult(Clump.value(1).apply()) ==== 1
-      awaitResult(Clump.value[Int](None)()) must throwA[NoSuchElementException]
+      awaitResult(Clump.empty[Int].apply()) must throwA[NoSuchElementException]
     }
 
     "can be made optional (clump.optional) to avoid lossy joins" in {

--- a/src/test/scala/io/getclump/ClumpExecutionSpec.scala
+++ b/src/test/scala/io/getclump/ClumpExecutionSpec.scala
@@ -109,7 +109,7 @@ class ClumpExecutionSpec extends Spec {
       "using a future clump as base" in new Context {
         val clump =
           for {
-            int <- Clump.future(Future.successful(Some(1)))
+            int <- Clump.future(Future.successful(1))
             collect1 <- Clump.collect(source1.get(int))
             collect2 <- Clump.collect(source2.get(int))
           } yield (collect1, collect2)


### PR DESCRIPTION
**Motivation**: Clump in general does a very good job of hiding its implementation details. For example, it's not required to know about `ClumpFlatMap`, `ClumpOrElse`, etc. to use the API. However, I feel like there's one place where this abstraction leaks: namely that values not returned by sources are internally stored as an `Option`.

This presents a major problem when working with `Clump[Option[T]]` because several APIs are overloaded and take `Option` to mean the underlying implementation `Option` and not the user facing `Option`.

Here's some examples of real problems we've had with this:

1: It leads to surprising types.
```scala
Clump.value(2): Clump[Int] // a value
Clump.value(List(2)): Clump[List[Int]] // a value with a context
Clump.value(Some(2)): Clump[Int] // a value again???
```

2: It requires awkward constructions to work with `Clump[Option[T]]`. 
```scala
// How do you create a Clump containing None?
Clump.value(None) // Wrong
Clump.value(Some(None)) // Correct but awkward
```

3: It can cause very subtle exceptions that are hard to find.
```scala
// An engineer on my team wrote this code:
val foo: Clump[Option[Profile]] = ...

foo.recover {
  // The intent here is to create a defined Clump containing None. However, this actually creates an undefined Clump.
  // This is not caught at compile time, and instead will fail ***at runtime*** even if you've defined a fallback for the inner Option.
  case e: D2ServiceException => None
  // This would be the correct line which, from the compilers perspective, is the same as the previous line
  case e: D2ServiceException => Some(None)
}
```

**Solution**: The solution is to remove any reference to the inner `Option` from the outer API. This includes removing any methods which were overloaded to accept both `T` and `Option[T]`.

Here's how using the API would change:

Desired Type | Before | After | Notes
--- | --- | --- | ---
`Clump[T]` | `Clump.value(None)` | `Clump.empty`
`Clump[Int]` | `Clump.value(Some(3))` | `Clump.value(3)` | Although `Clump.value(3)` already worked so you were probably using that anyway
`Clump[Option[Int]]` | `Clump.value(Some(None))` | `Clump.value(None)`
`Clump[Int]` | `Clump.future(Future(Some(3)))` | `Clump.future(Future(3))` | Although again `Clump.future(Future(3))` already worked
`Clump[Option[Int]]` | `Clump.future(Future(Some(None)))` | `Clump.future(Future(None))`
`Clump[T]` | `Clump.fallback(None)` | `Clump.fallbackTo(Clump.empty)` | `fallback` becomes `fallbackTo`
`Clump[Int]` | `Clump.fallback(Some(3))` | `Clump.fallback(3)`
`Clump[T]` | `Clump.handle { case _ => None }` | `Clump.rescue { case _ => Clump.empty }` | If one of your cases had None, then `handle` has to become `rescue`
`Clump[Int]` | `Clump.handle { case _ => Some(3) }` | `Clump.handle { case _ => 3 }`

**Benefits**:

- Everything that was possible is still possible, ie. I'm not removing any functionality
- API is simpler
- No more need to use `ClassTag` hack to overload methods with `Option[T]` and `T` versions (1)
- `Some(None)` no longer needed

(1) This is not technically true, `orElse` is still overloaded to accept both `T` and `Clump[T]`. To fix this, we'd have to come up with a different name for one of the methods. Perhaps `orDefault`?