### PR TITLE
Add docs to Clump and ClumpSource files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ dependent resources. Worse, this problem of batching is often accidentally overl
 Clump removes the need for the developer to even think about bulk-fetching, batching and retries, providing a powerful and composable interface for aggregating resources.
 
 An example of batching fetches using futures without Clump:
-(makes 1 call to tracksService and 1 call to usersService)
 
 ```scala
+// makes 1 call to tracksService and 1 call to usersService
 tracksService.get(trackIds).flatMap { tracks =>
   val userIds = tracks.map(_.creator)
   usersService.get(userIds).map { users =>
@@ -51,9 +51,9 @@ tracksService.get(trackIds).flatMap { tracks =>
 ```
 
 The same composition using Clump:
-(also makes just 1 call to tracksService and 1 call to usersService)
 
 ```scala
+// also makes just 1 call to tracksService and 1 call to usersService
 Clump.traverse(trackIds) { trackId =>
   for {
     track <- trackSource.get(trackId)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ Clump.traverse(trackIds) { trackId =>
   }
 ```
 
+## Users ##
+
+The following companies are running Clump in production:
+
+<img src="https://upload.wikimedia.org/wikipedia/en/9/92/SoundCloud_logo.svg" width="150" height="100"/>
+
+<img src="https://upload.wikimedia.org/wikipedia/commons/8/80/LinkedIn_Logo_2013.svg" width="150" height="100"/>
 
 ## Problem ##
 

--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -15,9 +15,9 @@ import scala.util.control.NonFatal
  * Clump removes the need for the developer to even think about bulk-fetching, batching and retries, providing a powerful and composable interface for aggregating resources.
  *
  * An example of batching fetches using futures without Clump:
- * (makes 1 call to tracksService and 1 call to usersService)
  *
  * {{{
+ * // makes 1 call to tracksService and 1 call to usersService
  * tracksService.get(trackIds).flatMap { tracks =>
  *   val userIds = tracks.map(_.creator)
  *   usersService.get(userIds).map { users =>
@@ -30,9 +30,9 @@ import scala.util.control.NonFatal
  * }}}
  *
  * The same composition using Clump:
- * (also makes just 1 call to tracksService and 1 call to usersService)
  *
  * {{{
+ * // also makes just 1 call to tracksService and 1 call to usersService
  * Clump.traverse(trackIds) { trackId =>
  *   for {
  *     track <- trackSource.get(trackId)

--- a/src/main/scala/io/getclump/ClumpSource.scala
+++ b/src/main/scala/io/getclump/ClumpSource.scala
@@ -3,6 +3,20 @@ package io.getclump
 import scala.collection.generic.CanBuildFrom
 
 
+/**
+ * Sources represent the remote systems' batched interfaces.
+ *
+ * There are multiple create a ClumpSource:
+ * - [[Clump.source]] with a function that returns a Map
+ * - [[Clump.source]] with a function that returns a collection and another function that maps values to keys
+ * - [[Clump.sourceTry]] with a function that returns a Map where each entry can be Success or Failure
+ * - [[Clump.sourceZip]] with a function that returns a List with the same order and size as the input list
+ * - [[Clump.sourceSingle]] with a function that accepts a single id and returns a single resource
+ *
+ * Once created, a Clump can be retrieved from an id using the [[get]] method.
+ *
+ * See [[Clump]]
+ */
 class ClumpSource[T, U] private[getclump] (val fetch: List[T] => Future[Map[T, Try[U]]],
                                            val maxBatchSize: Int = 100,
                                            val _maxRetries: PartialFunction[Throwable, Int] = PartialFunction.empty) {


### PR DESCRIPTION
In case anyone is browsing through a system and looks up a Clump, we want to have a good explanation of what it is in that file. Similar to the documentation above Future.